### PR TITLE
PXWEB2-39 Run Chromatic action when push to main

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,6 +3,11 @@
 name: 'Chromatic'
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'libs/pxweb2-ui/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Updates the Chromatic Github Action to run on pushes to the main branch, since chromatic needs this for the UI Reviews to work.

Did not update the workflow to trigger on all pushes, even though that might be what chromatic recommends. We do not know if we will need that yet, and we can change it when we see the need for it.