### PR TITLE
Move storybook-a11y to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@storybook/addon-a11y": "^7.6.10",
         "@swc/helpers": "~0.5.2",
         "clsx": "^2.1.0",
         "react": "18.2.0",
@@ -27,6 +26,7 @@
         "@nx/vite": "17.2.8",
         "@nx/web": "17.2.8",
         "@nx/workspace": "17.2.8",
+        "@storybook/addon-a11y": "^7.6.12",
         "@storybook/addon-essentials": "^7.5.3",
         "@storybook/addon-interactions": "^7.5.3",
         "@storybook/core-server": "^7.5.3",
@@ -7016,11 +7016,12 @@
       }
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.6.10.tgz",
-      "integrity": "sha512-TP17m4TAWLSSd2x9cWNg7d0MCZZCojYIG83RZMXAb55jt8gKJBMDbupOoDLydBsABQa5Uk9ZP0D/CvumMon8RA==",
+      "version": "7.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.6.12.tgz",
+      "integrity": "sha512-Y4vGTI7VslAt/PSpZZsFieceOkXHLagTsz9Zba4s1cw7Dd8KFB1+NcjkMmo6BhGq7K17JQljosXSbGhOoqrMVg==",
+      "dev": true,
       "dependencies": {
-        "@storybook/addon-highlight": "7.6.10",
+        "@storybook/addon-highlight": "7.6.12",
         "axe-core": "^4.2.0"
       },
       "funding": {
@@ -7029,9 +7030,10 @@
       }
     },
     "node_modules/@storybook/addon-a11y/node_modules/@storybook/addon-highlight": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.6.10.tgz",
-      "integrity": "sha512-dIuS5QmoT1R+gFOcf6CoBa6D9UR5/wHCfPqPRH8dNNcCLtIGSHWQ4v964mS5OCq1Huj7CghmR15lOUk7SaYwUA==",
+      "version": "7.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.6.12.tgz",
+      "integrity": "sha512-rWNEyBhwncXEDd9z7l67BLBIPqn0SRI/CJpZvCSF5KLWrVaoSEDF8INavmbikd1JBMcajJ28Ur6NsGj+eJjJiw==",
+      "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
       },
@@ -8698,7 +8700,8 @@
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
-      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true
     },
     "node_modules/@storybook/jest": {
       "version": "0.2.3",
@@ -12171,6 +12174,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.3.tgz",
       "integrity": "sha512-d5ZQHPSPkF9Tw+yfyDcRoUOc4g/8UloJJe5J8m4L5+c7AtDdjDLRxew/knnI4CxvtdxEUVgWz4x3OIQUIFiMfw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "private": true,
   "dependencies": {
-    "@storybook/addon-a11y": "^7.6.10",
     "@swc/helpers": "~0.5.2",
     "clsx": "^2.1.0",
     "react": "18.2.0",
@@ -29,6 +28,7 @@
     "@nx/vite": "17.2.8",
     "@nx/web": "17.2.8",
     "@nx/workspace": "17.2.8",
+    "@storybook/addon-a11y": "^7.6.12",
     "@storybook/addon-essentials": "^7.5.3",
     "@storybook/addon-interactions": "^7.5.3",
     "@storybook/core-server": "^7.5.3",


### PR DESCRIPTION
Since the addon was installed as a normal dependency by mistake, we move it to dev dependencies. This also updates it from 7.6.10 to 7.6.12.