### PR TITLE
Add dependabot config - dependency version control

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: lockfile-only
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Nx comes with local caching already built-in (check your `nx.json`). On CI you m
 
 - [Join the community](https://nx.dev/community)
 - [Subscribe to the Nx Youtube Channel](https://www.youtube.com/@nxdevtools)
-- [Follow us on Twitter](https://twitter.com/nxdevtools) 
+- [Follow us on Twitter](https://twitter.com/nxdevtools)

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Nx comes with local caching already built-in (check your `nx.json`). On CI you m
 
 - [Join the community](https://nx.dev/community)
 - [Subscribe to the Nx Youtube Channel](https://www.youtube.com/@nxdevtools)
-- [Follow us on Twitter](https://twitter.com/nxdevtools)
+- [Follow us on Twitter](https://twitter.com/nxdevtools) 


### PR DESCRIPTION
Since we want to have Dependabot help with updating versions of our dependencies, we need to add the configuration file for this.

However, we also have to make sure the dependencies are not updated past what is supported by Nx. Therefore we have opted to use the lockfile-only update strategy, and do manual updates also.