### PR TITLE
Reorganized translation file structure

### DIFF
--- a/apps/pxweb2/public/locales/ar/translation.json
+++ b/apps/pxweb2/public/locales/ar/translation.json
@@ -1,6 +1,12 @@
 {
-  "app_title": "مرحبًا بك في PxWeb",
-  "main": {
+  "common": {
+    "title": "مرحبًا بك في PxWeb 2.0",
+    "header": {
+      "title": "PxWeb 2.0",
+      "logo": "PxWeb 2.0"
+    }
+  },
+  "start_page": {
     "header": "مرحبا بكم في التطبيق!",
     "welcome_trans_test": "مرحبًا بك في <1>التطبيق</1> لـ PxWeb 2.0!"
   }

--- a/apps/pxweb2/public/locales/en/translation.json
+++ b/apps/pxweb2/public/locales/en/translation.json
@@ -1,8 +1,129 @@
 {
-  "app_title": "Welcome to PxWeb",
-  "main": {
+  "common": {
+    "title": "Welcome to PxWeb 2.0",
+    "header": {
+      "title": "PxWeb 2.0",
+      "logo": "PxWeb 2.0"
+    },
+    "footer": {
+      "contact": {
+        "title": "Contact",
+        "description": "Description text..."
+      },
+      "about": {
+        "title": "About",
+        "description": "Description text..."
+      },
+      "accessibility": {
+        "title": "Accessibility",
+        "description": "Description text..."
+      },
+      "version": {
+        "title": "Version",
+        "description": "Description text..."
+      }
+    },
+    "generic_buttons": {
+      "ok": "OK",
+      "cancel": "Cancel"
+    }
+  },
+  "start_page": {
     "header": "Welcome to the app!",
     "welcome_trans_test": "Welcome to the <1>app</1> for PxWeb 2.0!"
+  },
+  "presentation_page": {
+    "sidemenu": {
+      "hide": "Hide menu",
+      "selection": {
+        "title": "Filter"
+      },
+      "view": {
+        "title": "View",
+        "table": {
+          "title": "Table"
+        },
+        "graph": {
+          "title": "Graph"
+        }
+      },
+      "edit": {
+        "title": "Edit",
+        "customize": {
+          "title": "Customize",
+          "pivot": {
+            "title": "Pivot"
+          },
+          "rearrange": {
+            "title": "Rearrange table",
+            "description": "Description text..."
+          },
+          "change_order": {
+            "title": "Change order",
+            "description": "Description text..."
+          }
+        },
+        "calculate": {
+          "title": "Calculate",
+          "sum": {
+            "title": "Sum",
+            "description": "Description text..."
+          }
+        },
+        "hide_display": {
+          "title": "Hide/display"
+        }
+      },
+      "save": {
+        "title": "Save",
+        "file": {
+          "title": "Save as file",
+          "excel": "Excel (xlsx)"
+        },
+        "imagefile": {
+          "title": "Save as graph",
+          "png": "Chart (png)"
+        },
+        "link": {
+          "title": "Save as link",
+          "description": "Description text..."
+        },
+        "api": {
+          "title": "API",
+          "description": "Description text..."
+        }
+      },
+      "help": {
+        "title": "Help"
+      }
+    },
+    "main_content": {
+      "last_updated": "Last updated",
+      "show_details": "Show details",
+      "about_table": {
+        "title": "About the table",
+        "footnotes": {
+          "title": "Notes",
+          "show_all_footnotes": "Show all notes for table"
+        },
+        "information": {
+          "title": "Information",
+          "description": "The table is part of the statistics {{statistics}}"
+        },
+        "definition": {
+          "title": "Definitions",
+          "description": "Description text..."
+        },
+        "metadata": {
+          "title": "Metadata",
+          "description": "Description text..."
+        }
+      },
+      "related": {
+        "title": "Related",
+        "description": "Description text..."
+      }
+    }
   },
   "date": {
     "simple_date": "{{value, datetime}}",

--- a/apps/pxweb2/public/locales/no/translation.json
+++ b/apps/pxweb2/public/locales/no/translation.json
@@ -1,6 +1,12 @@
 {
-  "app_title": "Velkommen til PxWeb",
-  "main": {
+  "common": {
+    "title": "Velkommen til PxWeb 2.0",
+    "header": {
+      "title": "PxWeb 2.0",
+      "logo": "PxWeb 2.0"
+    }
+  },
+  "start_page": {
     "header": "Velkommen til appen!",
     "welcome_trans_test": "Velkommen til <1>appen</1> for PxWeb 2.0!"
   }

--- a/apps/pxweb2/public/locales/sv/translation.json
+++ b/apps/pxweb2/public/locales/sv/translation.json
@@ -1,6 +1,12 @@
 {
-  "app_title": "Välkommen till PxWeb",
-  "main": {
+  "common": {
+    "title": "Välkommen till PxWeb 2.0",
+    "header": {
+      "title": "PxWeb 2.0",
+      "logo": "PxWeb 2.0"
+    }
+  },
+  "start_page": {
     "header": "Välkommen till appen!",
     "welcome_trans_test": "Välkommen till <1>appen</1> för PxWeb 2.0!"
   }

--- a/apps/pxweb2/src/@types/resources.d.ts
+++ b/apps/pxweb2/src/@types/resources.d.ts
@@ -1,9 +1,130 @@
 interface Resources {
   "translation": {
-    "app_title": "Welcome to PxWeb",
-    "main": {
+    "common": {
+      "title": "Welcome to PxWeb 2.0",
+      "header": {
+        "title": "PxWeb 2.0",
+        "logo": "PxWeb 2.0"
+      },
+      "footer": {
+        "contact": {
+          "title": "Contact",
+          "description": "Description text..."
+        },
+        "about": {
+          "title": "About",
+          "description": "Description text..."
+        },
+        "accessibility": {
+          "title": "Accessibility",
+          "description": "Description text..."
+        },
+        "version": {
+          "title": "Version",
+          "description": "Description text..."
+        }
+      },
+      "generic_buttons": {
+        "ok": "OK",
+        "cancel": "Cancel"
+      }
+    },
+    "start_page": {
       "header": "Welcome to the app!",
       "welcome_trans_test": "Welcome to the <1>app</1> for PxWeb 2.0!"
+    },
+    "presentation_page": {
+      "sidemenu": {
+        "hide": "Hide menu",
+        "selection": {
+          "title": "Filter"
+        },
+        "view": {
+          "title": "View",
+          "table": {
+            "title": "Table"
+          },
+          "graph": {
+            "title": "Graph"
+          }
+        },
+        "edit": {
+          "title": "Edit",
+          "customize": {
+            "title": "Customize",
+            "pivot": {
+              "title": "Pivot"
+            },
+            "rearrange": {
+              "title": "Rearrange table",
+              "description": "Description text..."
+            },
+            "change_order": {
+              "title": "Change order",
+              "description": "Description text..."
+            }
+          },
+          "calculate": {
+            "title": "Calculate",
+            "sum": {
+              "title": "Sum",
+              "description": "Description text..."
+            }
+          },
+          "hide_display": {
+            "title": "Hide/display"
+          }
+        },
+        "save": {
+          "title": "Save",
+          "file": {
+            "title": "Save as file",
+            "excel": "Excel (xlsx)"
+          },
+          "imagefile": {
+            "title": "Save as graph",
+            "png": "Chart (png)"
+          },
+          "link": {
+            "title": "Save as link",
+            "description": "Description text..."
+          },
+          "api": {
+            "title": "API",
+            "description": "Description text..."
+          }
+        },
+        "help": {
+          "title": "Help"
+        }
+      },
+      "main_content": {
+        "last_updated": "Last updated",
+        "show_details": "Show details",
+        "about_table": {
+          "title": "About the table",
+          "footnotes": {
+            "title": "Notes",
+            "show_all_footnotes": "Show all notes for table"
+          },
+          "information": {
+            "title": "Information",
+            "description": "The table is part of the statistics {{statistics}}"
+          },
+          "definition": {
+            "title": "Definitions",
+            "description": "Description text..."
+          },
+          "metadata": {
+            "title": "Metadata",
+            "description": "Description text..."
+          }
+        },
+        "related": {
+          "title": "Related",
+          "description": "Description text..."
+        }
+      }
     },
     "date": {
       "simple_date": "{{value, datetime}}",

--- a/apps/pxweb2/src/app/app.tsx
+++ b/apps/pxweb2/src/app/app.tsx
@@ -50,10 +50,10 @@ export function App() {
         ))}
       </ul>
       <Heading level="1" size="xlarge">
-        Welcome to PxWeb 2.0
+        {t('common.title')}
       </Heading>
       <br />
-      <Ingress spacing>{t('main.header')}</Ingress>
+      <Ingress spacing>{t('start_page.header')}</Ingress>
       <BodyShort size="medium" spacing align="start" weight="regular">
         BodyShort: This component will be used for text with not more than 80
         characters.
@@ -118,10 +118,14 @@ export function App() {
         })}
       </p>
       <p>
-        <Trans i18nKey="main.welcome_trans_test">
+        <Trans i18nKey="start_page.welcome_trans_test">
           "Welcome to the <b>app</b> for PxWeb 2.0!"
         </Trans>
       </p>
+      <BodyShort size="medium" spacing align="start" weight="regular">
+        Example of getting a translation from a nested translation key:&nbsp;
+        {t('presentation_page.sidemenu.edit.customize.pivot.title')}
+      </BodyShort>
     </>
   );
 }

--- a/apps/pxweb2/src/i18n/useLocalizeDocumentAttributes.ts
+++ b/apps/pxweb2/src/i18n/useLocalizeDocumentAttributes.ts
@@ -10,7 +10,7 @@ export default function useLocalizeDocumentAttributes() {
       document.documentElement.dir = i18n.dir(i18n.resolvedLanguage);
     }
 
-    document.title = t('app_title');
+    document.title = t('common.title');
     
   }, [i18n, i18n.resolvedLanguage, t]);
 }


### PR DESCRIPTION
The structure of the translation files have been reorganized into sections that follow the structure of the PxWeb user interface.
Hopefully this will make it easy to find the translation text you are looking for.

Only the english translation file is totally updated. The other files only have a minimum of translations.

This is only a draft structure that might come to change later on. It is also possible to divide the translation file into multiple files later on.