### PR TITLE
Patch/pxweb2 154 update chromatic to v11

### DIFF
--- a/libs/pxweb2-ui/style-dictionary/README.md
+++ b/libs/pxweb2-ui/style-dictionary/README.md
@@ -5,4 +5,4 @@ Go to the root of the entire project and run
 
 ## Custom theme
 
-To use a custom theme you have to create a file called `custom_theme.json`. When building the results end up in /build/. The variables stored in `custom_theme.json` will be used instead of the variables in `default_theme.json` when building the variables to js and sass if both files are present. 
+To use a custom theme you have to create a file called `custom_theme.json`. When building the results end up in /build/. The variables stored in `custom_theme.json` will be used instead of the variables in `default_theme.json` when building the variables to js and sass if both files are present.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/coverage-v8": "1.4.0",
         "@vitest/ui": "1.4.0",
-        "chromatic": "^10.9.6",
+        "chromatic": "11.3.0",
         "cypress": "^13.7.1",
         "eslint": "8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -11882,9 +11882,9 @@
       }
     },
     "node_modules/chromatic": {
-      "version": "10.9.6",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-10.9.6.tgz",
-      "integrity": "sha512-1MoT+/U+vQwEiq2GuehPyStbqhxqHmM1B9pdpVU1dKh26userQg1FyOFYifkTgy+9reo2w2p7sAbc0JRd2kzlA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-11.3.0.tgz",
+      "integrity": "sha512-q1ZtJDJrjLGnz60ivpC16gmd7KFzcaA4eTb7gcytCqbaKqlHhCFr1xQmcUDsm14CK7JsqdkFU6S+JQdOd2ZNJg==",
       "dev": true,
       "bin": {
         "chroma": "dist/bin.js",
@@ -11892,8 +11892,8 @@
         "chromatic-cli": "dist/bin.js"
       },
       "peerDependencies": {
-        "@chromatic-com/cypress": "^0.5.2 || ^1.0.0",
-        "@chromatic-com/playwright": "^0.5.2 || ^1.0.0"
+        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
       },
       "peerDependenciesMeta": {
         "@chromatic-com/cypress": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "1.4.0",
     "@vitest/ui": "1.4.0",
-    "chromatic": "^10.9.6",
+    "chromatic": "11.3.0",
     "cypress": "^13.7.1",
     "eslint": "8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -78,3 +78,4 @@
   "readme": "ERROR: No README data found!",
   "_id": "@pxweb2/source@0.0.0"
 }
+


### PR DESCRIPTION
Since we want to keep the project up-yo-date, we need to update packages
that have breaking changes. The Chromatic v11+ breaking change has to do
with TurboSnap, and a new check for setting/telling the cli the baseDir
for storybook.

Since we do not use TurboSnap, and only used 1500 of our 5000 free
snapshots last month. Adding this can be done later, when we need to
look at ways to optimize the build process. Or we can drop it
entirely if we can upgrade our Chromatic project account to an Open
Source one. Though we still might want to do it just to not be wasteful.