### PR TITLE
Feature/pxweb2 156 add text style to heading

### DIFF
--- a/apps/pxweb2/src/app/app.module.scss
+++ b/apps/pxweb2/src/app/app.module.scss
@@ -5,7 +5,7 @@
   width: 100%;
 }
 
-@media (min-width: fixed.$breakpoints-x-small-min-width) and (max-width: fixed.$breakpoints-x-small-max-width) {
+@media (min-width: fixed.$breakpoints-xsmall-min-width) and (max-width: fixed.$breakpoints-xsmall-max-width) {
   .breakpoints {
     max-width: 100px;
     color: white;
@@ -34,7 +34,7 @@
   }
 }
 
-@media (min-width: fixed.$breakpoints-x-large-min-width) {
+@media (min-width: fixed.$breakpoints-xlarge-min-width) {
   .breakpoints {
     max-width: 700px;
     background-color: yellow;

--- a/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.module.scss
@@ -2,9 +2,7 @@
 @use '../../../text-styles.scss';
 
 .heading {
-  color: var(--px-color-text-default);
   margin: 0;
-  text-align: left;
 }
 
 .xsmall {

--- a/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.module.scss
@@ -1,56 +1,37 @@
 @use '../../../../../style-dictionary/dist/scss/fixed-variables.scss' as fixed;
+@use '../../../text-styles.scss';
 
 .heading {
-  font-family: PxWeb-font-700;
   color: var(--px-color-text-default);
   margin: 0;
+  text-align: left;
 }
 
 .xsmall {
-  font-size: 1rem;
-  line-height: 1.625rem;
-  letter-spacing: 0em;
-  text-align: left;
   &.spacing {
     margin-bottom: fixed.$spacing-1;
   }
 }
 
 .small {
-  font-size: 1.25rem;
-  line-height: 1.75;
-  letter-spacing: 0.005em;
-  text-align: left;
   &.spacing {
     margin-bottom: fixed.$spacing-1;
   }
 }
 
 .medium {
-  font-size: 1.5rem;
-  line-height: 2.25rem;
-  letter-spacing: 0em;
-  text-align: left;
   &.spacing {
     margin-bottom: fixed.$spacing-3;
   }
 }
 
 .large {
-  font-size: 2rem;
-  line-height: 2.75rem;
-  letter-spacing: 0em;
-  text-align: left;
   &.spacing {
     margin-bottom: fixed.$spacing-5;
   }
 }
 
 .xlarge {
-  font-size: 2.5rem;
-  line-height: 3.5rem;
-  letter-spacing: 0em;
-  text-align: left;
   &.spacing {
     margin-bottom: fixed.$spacing-6;
   }

--- a/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.spec.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.spec.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
 
-import Heading from './Heading';
+import { Heading } from './Heading';
 
 describe('Heading', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<Heading />);
+    const { baseElement } = render(<Heading>test</Heading>);
     expect(baseElement).toBeTruthy();
   });
 });

--- a/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.stories.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+
 import { Heading } from './Heading';
 
 const meta: Meta<typeof Heading> = {

--- a/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.tsx
@@ -1,6 +1,7 @@
-import cl from 'clsx';
-import classes from './Heading.module.scss';
 import React from 'react';
+import cl from 'clsx';
+
+import classes from './Heading.module.scss';
 
 /* eslint-disable-next-line */
 export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {

--- a/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Typography/Heading/Heading.tsx
@@ -30,6 +30,7 @@ export function Heading({
       className={cl(
         classes.heading,
         classes[size],
+        classes[`heading-${size}`],
         { [classes.spacing]: spacing },
         classes[`align-${align}`],
         classes[`text-color-${textcolor}`]

--- a/libs/pxweb2-ui/src/lib/text-styles.scss
+++ b/libs/pxweb2-ui/src/lib/text-styles.scss
@@ -1,3 +1,5 @@
+@use '../../style-dictionary/dist/scss/fixed-variables.scss' as fixed;
+
 .label-small {
   font-family: PxWeb-font-500;
   font-style: normal;
@@ -14,3 +16,60 @@
   line-height: 1.5rem; /* 150% */
 }
 
+/* Heading/Desktop/XSmall */
+.heading-xsmall {
+  font-family: PxWeb-font-700;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 1.625rem; /* 162.5% */
+}
+
+/* Heading/Desktop/Small */
+.heading-small {
+  font-family: PxWeb-font-700;
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 1.75rem; /* 175% */
+  letter-spacing: 0.00625em;
+}
+
+/* Heading/Desktop/Medium */
+.heading-medium {
+  font-family: PxWeb-font-700;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2.25rem; /* 225% */
+}
+
+/* Heading/Desktop/Large */
+.heading-large {
+  font-family: PxWeb-font-700;
+  font-size: 2rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2.75rem; /* 275% */
+
+  /* Heading/Mobile/Large */
+  @media screen and (max-width: fixed.$breakpoints-xsmall-max-width) {
+    font-size: 1.75rem;
+    line-height: 2.25rem; /* 225% */
+  }
+}
+
+/* Heading/Desktop/XLarge */
+.heading-xlarge {
+  font-family: PxWeb-font-700;
+  font-size: 2.5rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 3.5rem; /* 350% */
+
+  /* Heading/Mobile/XLarge */
+  @media screen and (max-width: fixed.$breakpoints-xsmall-max-width) {
+    font-size: 2rem;
+    line-height: 2.75rem; /* 275% */
+  }
+}

--- a/libs/pxweb2-ui/src/lib/text-styles.scss
+++ b/libs/pxweb2-ui/src/lib/text-styles.scss
@@ -32,7 +32,7 @@
   font-style: normal;
   font-weight: 700;
   line-height: 1.75rem; /* 175% */
-  letter-spacing: 0.00625em;
+  letter-spacing: 0.00625rem;
 }
 
 /* Heading/Desktop/Medium */

--- a/libs/pxweb2-ui/src/lib/text-styles.scss
+++ b/libs/pxweb2-ui/src/lib/text-styles.scss
@@ -53,7 +53,7 @@
   line-height: 2.75rem; /* 275% */
 
   /* Heading/Mobile/Large */
-  @media screen and (max-width: fixed.$breakpoints-xsmall-max-width) {
+  @media screen and (min-width: fixed.$breakpoints-xsmall-min-width) and (max-width: fixed.$breakpoints-xsmall-max-width) {
     font-size: 1.75rem;
     line-height: 2.25rem; /* 225% */
   }
@@ -68,7 +68,7 @@
   line-height: 3.5rem; /* 350% */
 
   /* Heading/Mobile/XLarge */
-  @media screen and (max-width: fixed.$breakpoints-xsmall-max-width) {
+  @media screen and (min-width: fixed.$breakpoints-xsmall-min-width) and (max-width: fixed.$breakpoints-xsmall-max-width) {
     font-size: 2rem;
     line-height: 2.75rem; /* 275% */
   }

--- a/libs/pxweb2-ui/style-dictionary/src/global-tokens/breakpoints.json
+++ b/libs/pxweb2-ui/style-dictionary/src/global-tokens/breakpoints.json
@@ -1,6 +1,6 @@
 {
   "breakpoints": {
-    "XSmall": {
+    "xsmall": {
       "MinWidth": {
         "value": "0px"
       },
@@ -8,7 +8,7 @@
         "value": "479px"
       }
     },
-    "Small": {
+    "small": {
       "MinWidth": {
         "value": "480px"
       },
@@ -16,7 +16,7 @@
         "value": "689px"
       }
     },
-    "Medium": {
+    "medium": {
       "MinWidth": {
         "value": "690px"
       },
@@ -24,7 +24,7 @@
         "value": "1259px"
       }
     },
-    "Large": {
+    "large": {
       "MinWidth": {
         "value": "1260px"
       },
@@ -32,7 +32,7 @@
         "value": "1599px"
       }
     },
-    "XLarge": {
+    "xlarge": {
       "MinWidth": {
         "value": "1600px"
       }


### PR DESCRIPTION
Since we want to use global text styles, instead of each component
having it's own text styling, we need to update the Heading component.

This also updates the text styles of the Heading component to the
latest ones from Figma.