### PR TITLE
Fix missing cursor pointer on VariabelBoxHeader

### DIFF
--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.module.scss
@@ -7,6 +7,7 @@
   align-self: stretch;
   padding: fixed.$spacing-3 fixed.$spacing-3 fixed.$spacing-5 fixed.$spacing-5;
   gap: 1rem;
+  cursor: pointer;
 
   /* Style */
   background: var(--px-color-surface-default);


### PR DESCRIPTION
Since we want the indications for when something can be pressed to be clear, we need to change the mouse cursor when hovering over the clickable header of the VariableBox component.