### PR TITLE
Fix using wrong units for setting font-values

### DIFF
--- a/libs/pxweb2-ui/src/lib/components/Checkbox/Checkbox.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/Checkbox/Checkbox.module.scss
@@ -53,8 +53,8 @@
   font-family: PxWeb-font-400;
   letter-spacing: 0em;
   color: var(--px-color-text-default);
-  line-height: 24px;
-  font-size: 16px;
+  line-height: 1.5rem;
+  font-size: 1rem;
 }
 .strong {
   font-family: PxWeb-font-700;


### PR DESCRIPTION
Since we want the user's font size settings in the browser to be respected, we need to use units for setting the font-sizing and similar, that respect those settings. Since "px" does not allow this, we need to change the places where they are used for that.

The visual problems with showing multiple lines in checkboxes are not because of this change. That is because of "min-height" on Checkbox, and "max-height" on it's container do not work correctly together. It will be fixed separatly.