### PR TITLE
Capitalize the first letter of valuename in VB

### DIFF
--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -14,7 +14,10 @@ type MappedCodeList = {
   value: string;
   label: string;
 };
-type VariableBoxPropsToContent = Omit<VariableBoxProps, 'id' | 'mandatory' | 'tableId'>;
+type VariableBoxPropsToContent = Omit<
+  VariableBoxProps,
+  'id' | 'mandatory' | 'tableId'
+>;
 
 /* eslint-disable-next-line */
 type VariableBoxContentProps = VariableBoxPropsToContent & {
@@ -231,7 +234,9 @@ export function VariableBoxContent({
                     .find((variables) => variables.id === varId)
                     ?.values.includes(value.code) === true
                 }
-                text={value.label}
+                text={
+                  value.label.charAt(0).toUpperCase() + value.label.slice(1)
+                }
                 onChange={() => onChangeCheckbox(varId, value.code)}
               />
             ))}


### PR DESCRIPTION
Since we want the language in the application to look correct and professional, we need to make sure we capitalize the first letter of value names in the list of checkboxes in the variable box.

Line 17 was changed by the autoformatter.