### PR TITLE
Fix/hover on search in variablebox

### DIFF
--- a/libs/pxweb2-ui/src/lib/components/Search/Search.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/Search/Search.module.scss
@@ -40,6 +40,7 @@
   border-radius: var(--px-border-radius-medium);
   background: var(--px-color-surface-subtle);
   z-index: 1;
+  outline-offset: -2px;
 
   &:hover {
     border-radius: var(--px-border-radius-medium);

--- a/libs/pxweb2-ui/src/lib/components/Search/Search.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/Search/Search.module.scss
@@ -39,6 +39,7 @@
 .inVariableBox {
   border-radius: var(--px-border-radius-medium);
   background: var(--px-color-surface-subtle);
+  z-index: 1;
 
   &:hover {
     border-radius: var(--px-border-radius-medium);

--- a/libs/pxweb2-ui/src/lib/components/Search/Search.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/Search/Search.module.scss
@@ -19,36 +19,36 @@
 }
 
 .default {
-  border-radius: var(--px-border-radius-small, 0.25rem);
-  outline: 2px solid var(--px-color-border-default, #62919a);
-  background: var(--px-color-surface-default, #fff);
+  border-radius: var(--px-border-radius-small);
+  outline: 2px solid var(--px-color-border-default);
+  background: var(--px-color-surface-default);
 
   &:hover {
-    border-radius: var(--px-border-radius-small, 0.25rem);
-    outline: 2px solid var(--px-color-border-hover, #62919a);
-    background: var(--px-color-surface-default, #fff);
+    border-radius: var(--px-border-radius-small);
+    outline: 2px solid var(--px-color-border-hover);
+    background: var(--px-color-surface-default);
   }
 
   &:active {
-    border-radius: var(--px-border-radius-small, 0.25rem);
-    outline: 2px solid var(--px-color-border-action, #274247);
-    background: var(--px-color-surface-default, #fff);
+    border-radius: var(--px-border-radius-small);
+    outline: 2px solid var(--px-color-border-action);
+    background: var(--px-color-surface-default);
   }
 }
 
 .inVariableBox {
-  border-radius: var(--px-border-radius-medium, 0.5rem);
-  background: var(--px-color-surface-subtle, #f0f8f9);
+  border-radius: var(--px-border-radius-medium);
+  background: var(--px-color-surface-subtle);
 
   &:hover {
-    border-radius: var(--px-border-radius-medium, 0.5rem);
-    outline: 2px solid var(--px-color-border-action, #274247);
+    border-radius: var(--px-border-radius-medium);
+    outline: 2px solid var(--px-color-border-action);
   }
 
   &:active {
-    border-radius: var(--px-border-radius-medium, 0.5rem);
-    outline: 2px solid var(--px-color-border-action, #274247);
-    background: var(--px-color-surface-default, #fff);
+    border-radius: var(--px-border-radius-medium);
+    outline: 2px solid var(--px-color-border-action);
+    background: var(--px-color-surface-default);
   }
 }
 
@@ -93,7 +93,7 @@
 }
 
 ::placeholder {
-  color: var(--px-color-text-subtle, #2d6975);
+  color: var(--px-color-text-subtle);
 }
 
 .searchIcon {
@@ -101,13 +101,13 @@
 }
 
 .wrapper.default:focus-within {
-  border-radius: var(--px-border-radius-small, 0.25rem);
-  outline: 2px solid var(--px-color-border-action, #274247);
-  background: var(--px-color-surface-default, #fff);
+  border-radius: var(--px-border-radius-small);
+  outline: 2px solid var(--px-color-border-action);
+  background: var(--px-color-surface-default);
 }
 
 .wrapper.inVariableBox:focus-within {
-  border-radius: var(--px-border-radius-medium, 0.5rem);
-  outline: 2px solid var(--px-color-border-action, #274247);
-  background: var(--px-color-surface-default, #fff);
+  border-radius: var(--px-border-radius-medium);
+  outline: 2px solid var(--px-color-border-action);
+  background: var(--px-color-surface-default);
 }


### PR DESCRIPTION
When hovering, or focusing the Search in the VariableBox, the outline was only showing in the corners of the Search.

This turned out to be two problems, the bottom of the outline was going behind the background of the MixedCheckbox. Which only needed some z-index adjusting to work correctly. 

The other problem is that the outline goes outside the scrollable list, but with `overflow-y: auto` these are then removed therefore. I could not figure out how to solve this completely, without having to use alot more time. I considered 2 solutions here:

1. To moved the search outside the scrollable list. This should make it look correct, but would remove the scrolling functionality of it.
2. To add an offset on the outline, so it is inside of the scrollable list.

I chose to implement option 2 since it was 1 line of code, while keeping the scrolling intact. But this will be discussed with the designer on Monday, and is a TEMPORARY fix.

Also removed defaults in the CSS, since we want to be certain where CSS values come from.