### PR TITLE
Fix for spacebar scrolling when selecting checkbox

### DIFF
--- a/libs/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
@@ -32,7 +32,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       aria-labelledby={id + '-label'}
       className={styles.checkboxWrapper}
       tabIndex={tabIndex ? tabIndex : 0}
-      onKeyUp={(event) => {
+      onKeyDown={(event) => {
         if (event.key === ' ' || event.key === 'Enter') {
           event.preventDefault();
           onChange(!value);


### PR DESCRIPTION
Since we want to use the spacebar to select/toggle checkboxes, we need to override the default scrolling behaviour. However, this should only be done when on a checkbox.

Changing the keyUp event to keyDown, correctly overrides this.