### PR TITLE
Fix h-tag mistakenly used in VarBox header element

### DIFF
--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.module.scss
@@ -1,4 +1,5 @@
 @use '../../../../../style-dictionary/dist/scss/fixed-variables.scss' as fixed;
+@use '../../../text-styles.scss' as textStyles;
 
 .variablebox-header {
   /* Layout */
@@ -41,6 +42,7 @@
   align-items: flex-start;
   align-self: stretch;
   padding-top: 0.125rem;
+  margin: 0;
 }
 
 .header-tags {

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import classes from './VariableBoxHeader.module.scss';
 import { Icon } from '../../Icon/Icon';
 import Tag from '../../Tag/Tag';
-import Heading from '../../Typography/Heading/Heading';
 import { VariableBoxProps } from '../VariableBox';
 
 /* eslint-disable-next-line */
@@ -53,10 +52,12 @@ export function VariableBoxHeader({
       tabIndex={tabIndex}
     >
       <div className={cl(classes['header-title-and-tag'])}>
-        {/* TODO: Is this the right level for Heading here? */}
-        <Heading level="3" className={cl(classes['header-title'])} size="small">
+        <p className={cl(
+          classes['header-title'],
+          classes['heading-small'],
+          )}>
           {label}
-        </Heading>
+        </p>
         <div className={cl(classes['header-tags'])}>
           <Tag variant="neutral">
             {t(


### PR DESCRIPTION
The header of the variablebox should not have an actual h-tag.

Change it to a p-tag with the correct styling.