### PR TITLE
Fix missing max-width on footer

### DIFF
--- a/apps/pxweb2/src/app/components/Footer/Footer.module.scss
+++ b/apps/pxweb2/src/app/components/Footer/Footer.module.scss
@@ -2,6 +2,7 @@
 
 .footer {
   width: calc(100% - fixed.$spacing-6 * 2);
+  max-width: 1320px;
   background-color: var(--px-color-background-default);
   display: flex;
   flex-direction: column;

--- a/libs/pxweb2-ui/style-dictionary/README.md
+++ b/libs/pxweb2-ui/style-dictionary/README.md
@@ -6,4 +6,3 @@ Go to the root of the entire project and run
 ## Custom theme
 
 To use a custom theme you have to create a file called `custom_theme.json`. When building the results end up in /build/. The variables stored in `custom_theme.json` will be used instead of the variables in `default_theme.json` when building the variables to js and sass if both files are present.
- 


### PR DESCRIPTION
Simple fix for the Footer component missing the same max-width as the Content component