### PR TITLE
Fix empty state to be at the correct position

### DIFF
--- a/apps/pxweb2/src/app/app.tsx
+++ b/apps/pxweb2/src/app/app.tsx
@@ -510,7 +510,6 @@ export function App() {
   const drawerEdit = <>Edit content</>;
   const drawerSave = <>Save content</>;
   const drawerHelp = <>Help content</>;
-  
 
   return (
     <>
@@ -523,7 +522,7 @@ export function App() {
           />
           {selectedNavigationView !== 'none' && (
             <NavigationDrawer
-              heading={t('presentation_page.sidemenu.selection.title')} 
+              heading={t('presentation_page.sidemenu.selection.title')}
               onClose={() => {
                 setSelectedNavigationView('none');
               }}
@@ -543,28 +542,32 @@ export function App() {
           />
         </div>
         <Content topLeftBorderRadius={selectedNavigationView === 'none'}>
-
-          {!isMissingMandatoryVariables && tableData.data && pxTableMetadata && (
+          {tableData.data && pxTableMetadata && (
             <>
-              <ContentTop staticTitle={pxTableMetadata?.label} pxtable={JSON.parse(tableData.data) } />
+              <ContentTop
+                staticTitle={pxTableMetadata?.label}
+                pxtable={JSON.parse(tableData.data)}
+              />
 
-              <div>
-                <Table pxtable={JSON.parse(tableData.data)} />
-              </div>
+              {!isMissingMandatoryVariables && (
+                <div>
+                  <Table pxtable={JSON.parse(tableData.data)} />
+                </div>
+              )}
+
+              {!isLoadingMetadata && isMissingMandatoryVariables && (
+                <EmptyState
+                  headingTxt={t(
+                    'presentation_page.main_content.table.warnings.missing_mandatory.title'
+                  )}
+                >
+                  {t(
+                    'presentation_page.main_content.table.warnings.missing_mandatory.description'
+                  )}
+                </EmptyState>
+              )}
             </>
-
           )}{' '}
-          {!isLoadingMetadata && isMissingMandatoryVariables && (
-            <EmptyState
-              headingTxt={t(
-                'presentation_page.main_content.table.warnings.missing_mandatory.title'
-              )}
-            >
-              {t(
-                'presentation_page.main_content.table.warnings.missing_mandatory.description'
-              )}
-            </EmptyState>
-          )}
         </Content>
       </div>
     </>

--- a/libs/pxweb2-ui/style-dictionary/README.md
+++ b/libs/pxweb2-ui/style-dictionary/README.md
@@ -6,3 +6,4 @@ Go to the root of the entire project and run
 ## Custom theme
 
 To use a custom theme you have to create a file called `custom_theme.json`. When building the results end up in /build/. The variables stored in `custom_theme.json` will be used instead of the variables in `default_theme.json` when building the variables to js and sass if both files are present.
+ 


### PR DESCRIPTION
Since we only want the EmptyState warning to be rendered at the correct position on the table view, we need to move where the check is being done. This correctly only replaces the table in the table view, and not the entire content view.