### PR TITLE
fix/Refactor scss to have nesting at the end of class

### DIFF
--- a/apps/pxweb2/src/app/components/Content/Content.module.scss
+++ b/apps/pxweb2/src/app/components/Content/Content.module.scss
@@ -1,11 +1,12 @@
 @use '$ui/style-dictionary/dist/scss/fixed-variables.scss' as fixed;
 
 .contentWrapper {
+  width: 100%;
+  overflow: hidden;
+
   @media (min-width: fixed.$breakpoints-medium-min-width) {
     background-color: var(--px-color-background-subtle);
   }
-  width: 100%;
-  overflow: hidden;
 }
 
 .topLeftBorderRadius {
@@ -15,9 +16,6 @@
 .content {
   min-height: 100%;
   margin: fixed.$spacing-6;
-  @media (min-width: fixed.$breakpoints-medium-min-width) {
-    padding: fixed.$spacing-12;
-  }
   
   background-color: var(--px-color-background-default);
   border-radius: var(--px-border-radius-xlarge);
@@ -28,4 +26,8 @@
   align-items: flex-start;
   gap: fixed.$spacing-10;
   flex: 1 0 0;
+
+  @media (min-width: fixed.$breakpoints-medium-min-width) {
+    padding: fixed.$spacing-12;
+  }
 }

--- a/libs/pxweb2-ui/src/lib/components/Modal/Modal.module.scss
+++ b/libs/pxweb2-ui/src/lib/components/Modal/Modal.module.scss
@@ -4,10 +4,6 @@
   display: flex;
   width: 412px;
 
-  @media (min-width: fixed.$breakpoints-xsmall-min-width) and (max-width: fixed.$breakpoints-xsmall-max-width) {
-    width: 348px;
-  }
-
   flex-direction: column;
   align-items: center;
   border-radius: var(--px-border-radius-xlarge);
@@ -16,6 +12,10 @@
   // Not from Figma
   padding: 0px 0px 0px 0px;
   border-style: none;
+
+  @media (min-width: fixed.$breakpoints-xsmall-min-width) and (max-width: fixed.$breakpoints-xsmall-max-width) {
+    width: 348px;
+  }
 }
 
 .modal::backdrop {


### PR DESCRIPTION
Since we do not want our build output to have unnecessary warnings, we need to fix what we can when we have them. This fixes some warnings about nesting in .scss where there are more styling afterwards. This will be changed in a future version of scss.