### PR TITLE
Add check for empty errorMsg to tableprovider

### DIFF
--- a/apps/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/apps/pxweb2/src/app/context/TableDataProvider.tsx
@@ -1,7 +1,12 @@
 import { i18n } from 'i18next';
 import React, { createContext, useState, useEffect, ReactNode } from 'react';
 import useVariables from './useVariables';
-import { Dataset, TableService, VariableSelection, VariablesSelection } from '@pxweb2/pxweb2-api-client';
+import {
+  Dataset,
+  TableService,
+  VariableSelection,
+  VariablesSelection,
+} from '@pxweb2/pxweb2-api-client';
 import { PxTable } from '@pxweb2/pxweb2-ui';
 import { mapJsonStat2Response } from '../../mappers/JsonStat2ResponseMapper';
 
@@ -29,12 +34,13 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
   const variables = useVariables();
 
   useEffect(() => {
-    console.error('ERROR: TableDataProvider:', errorMsg);
+    if (errorMsg !== '') {
+      console.error('ERROR: TableDataProvider:', errorMsg);
+    }
   }, [errorMsg]);
 
   const fetchTableData = async (tableId: string, i18n: i18n) => {
-   
-    const selections : Array<VariableSelection> = [];
+    const selections: Array<VariableSelection> = [];
     const ids = variables.getUniqueIds();
     ids.forEach((id) => {
       const selection: VariableSelection = {
@@ -43,8 +49,8 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
       };
       selections.push(selection);
     });
-    
-    const variablesSelection : VariablesSelection = {selection: selections};
+
+    const variablesSelection: VariablesSelection = { selection: selections };
 
     const res = await TableService.getTableDataByPost(
       tableId,

--- a/libs/pxweb2-ui/README.md
+++ b/libs/pxweb2-ui/README.md
@@ -5,4 +5,3 @@ This library was generated with [Nx](https://nx.dev).
 ## Running unit tests
  
 Run `nx test pxweb2-ui` to execute the unit tests via [Vitest](https://vitest.dev/).
-


### PR DESCRIPTION
Since we do not want unecessary warnings or errors in the console, we need to remove the ones that appear. This fixes two errors when loading the site, because the useEffect in tableprovider for showing the errors in the console was missing a check for an empty string.