### PR TITLE
Fix missing unique keys in variableBox component

### DIFF
--- a/apps/pxweb2/src/app/app.tsx
+++ b/apps/pxweb2/src/app/app.tsx
@@ -228,7 +228,6 @@ export function App() {
   }
 
   useEffect(() => {
-
     const hasSelectedMandatoryVariables = pxTableMetadata?.variables
       .filter((variable) => variable.mandatory)
       .every((variable) =>
@@ -489,7 +488,6 @@ export function App() {
       <br />
       <br />
       <div className={styles.variableBoxContainer}>
-        {/* TODO: I think the warning in the console about unique IDs is the variable.id below*/}
         {!isLoadingMetadata &&
           pxTableMetaToRender &&
           pxTableMetaToRender.variables.length > 0 &&
@@ -498,6 +496,7 @@ export function App() {
               variable.id && (
                 <VariableBox
                   id={variable.id}
+                  key={variable.id + pxTableMetaToRender.id}
                   initialIsOpen={index === 0}
                   tableId={pxTableMetaToRender.id}
                   label={variable.label}

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -322,6 +322,7 @@ export function VariableBoxContent({
               {values.map((value) => (
                 <Checkbox
                   id={value.code}
+                  key={varId + value.code}
                   tabIndex={-1}
                   value={
                     selectedValues?.length > 0 &&


### PR DESCRIPTION
Since we do not want unnecessary errors and warnings in the console, we need to fix the long standing issues of the warnings for missing keys for the variableBox component. There were two such warnings, and this should fix both(finally).