### PR TITLE
fix/PxWeb2-270: Add new Chromatic workflow to skip if no ui change

### DIFF
--- a/.github/workflows/chromatic-skip.yml
+++ b/.github/workflows/chromatic-skip.yml
@@ -1,0 +1,33 @@
+# .github/workflows/chromatic-skip.yml
+
+name: 'Chromatic'
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'libs/pxweb2-ui/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'libs/pxweb2-ui/**'
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          skip: true


### PR DESCRIPTION
Since we want to require Chromatic checks to pass before merge to main, we need a workflow to pass those required checks when there are no changes that are related to the UI. As far as I know, there are no ways to test workflows locally before atleast a minimal version is added to main.

The skip workflow is simple, and this is an 'inverted' version of our old workflow. Will need to see if it works in main. Future work and debugging could possibly be done in a new branch, once this file has been added to main so it shows up in GitHub Actions page.