### PR TITLE
fix/PxWeb2-283: Fix for getting defaultSelection for new table

### DIFF
--- a/apps/pxweb2/src/app/app.tsx
+++ b/apps/pxweb2/src/app/app.tsx
@@ -192,6 +192,7 @@ export type NavigationItem =
 
 export function App() {
   const { tableId } = useParams<{ tableId: string }>();
+  const [prevTableId, setPrevTableId] = useState('');
   const navigate = useNavigate();
   const { i18n, t } = useTranslation();
   const variables = useVariables();
@@ -251,8 +252,16 @@ export function App() {
   }, [variables, i18n.resolvedLanguage]); // Should only run this useEffect when selectedVBValues are in sync with variables context
 
   useEffect(() => {
+    let shouldGetDefaultSelection = !hasLoadedDefaultSelection;
+
     if (!tableId) {
       return;
+    }
+
+    if (prevTableId === '' || prevTableId !== tableId) {
+      setHasLoadedDefaultSelection(false);
+      shouldGetDefaultSelection = true;
+      setPrevTableId(tableId);
     }
 
     if (isLoadingMetadata === false) {
@@ -260,7 +269,6 @@ export function App() {
     }
 
     TableService.getMetadataById(tableId, i18n.resolvedLanguage)
-
       .then((tableMetadataResponse) => {
         const pxTabMetadata: PxTableMetadata = mapTableMetadataResponse(
           tableMetadataResponse
@@ -272,7 +280,7 @@ export function App() {
         setErrorMsg('');
       })
       .then(() => {
-        if (hasLoadedDefaultSelection) {
+        if (!shouldGetDefaultSelection) {
           setIsLoadingMetadata(false);
 
           return;


### PR DESCRIPTION
Since we want to only get the default selection when you change tables, we need to correctly keep track of the old table id, so we know when to grab the default selection again.

This is a fix for the prior PR that was merged on this issue, PxWeb2-283.