### PR TITLE
TableDataProvider stores a PxTable object instead of a string

### DIFF
--- a/apps/pxweb2/src/app/app.tsx
+++ b/apps/pxweb2/src/app/app.tsx
@@ -561,12 +561,12 @@ export function App() {
             <>
               <ContentTop
                 staticTitle={pxTableMetadata?.label}
-                pxtable={JSON.parse(tableData.data)}
+                pxtable={tableData.data}
               />
 
               {!isMissingMandatoryVariables && (
                 <div className={styles.tableWrapper}>
-                  <Table pxtable={JSON.parse(tableData.data)} />
+                  <Table pxtable={tableData.data} />
                 </div>
               )}
 

--- a/apps/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/apps/pxweb2/src/app/context/TableDataProvider.tsx
@@ -12,7 +12,7 @@ import { mapJsonStat2Response } from '../../mappers/JsonStat2ResponseMapper';
 
 // Define types for the context state and provider props
 export interface TableDataContextType {
-  data: any;
+  data: PxTable | undefined;
   /*   loading: boolean;
   error: string | null; */
   fetchTableData: (tableId: string, i18n: i18n) => void;
@@ -24,12 +24,12 @@ interface TableDataProviderProps {
 
 // Create context with default values
 const TableDataContext = createContext<TableDataContextType | undefined>({
-  data: '',
+  data: undefined,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   fetchTableData: () => {},
 });
 const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
-  const [data, setData] = useState<string>();
+  const [data, setData] = useState<PxTable | undefined>(undefined);
   const [errorMsg, setErrorMsg] = useState('');
   const variables = useVariables();
 
@@ -65,7 +65,7 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
 
     const pxTable: PxTable = mapJsonStat2Response(pxTabData);
 
-    setData(JSON.stringify(pxTable));
+    setData(pxTable);
   };
 
   return (


### PR DESCRIPTION
TableDataProvider now stores a PxTable object instead of a string in context.
In this way we do not need to call JSON.stringify and JSON.parse when storing the PxTable in context and using it in our components which is more efficient. 