### PR TITLE
fix/Add so VariableBox reverses values order when it is a time variable

### DIFF
--- a/apps/pxweb2/src/app/app.tsx
+++ b/apps/pxweb2/src/app/app.tsx
@@ -509,6 +509,7 @@ export function App() {
                   tableId={pxTableMetaToRender.id}
                   label={variable.label}
                   mandatory={variable.mandatory}
+                  type={variable.type}
                   values={variable.values}
                   codeLists={variable.codeLists}
                   selectedValues={selectedVBValues}

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBox.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBox.tsx
@@ -15,7 +15,7 @@ export type SelectedVBValues = {
 };
 
 /* eslint-disable-next-line */
-export type VariableBoxPropsBase = Omit<Variable, 'type' | 'notes'>;
+export type VariableBoxPropsBase = Omit<Variable, 'notes'>;
 
 export type VariableBoxProps = VariableBoxPropsBase & {
   tableId: string;
@@ -35,6 +35,7 @@ export function VariableBox({
   tableId,
   label,
   mandatory = false,
+  type,
   values,
   codeLists,
   selectedValues,
@@ -87,6 +88,7 @@ export function VariableBox({
       {isOpen && (
         <VariableBoxContent
           varId={id}
+          type={type}
           label={capitalizedVariableName}
           values={values}
           codeLists={codeLists}

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.spec.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.spec.tsx
@@ -1,12 +1,14 @@
-import { render } from '@testing-library/react';
+import { getAllByRole, render } from '@testing-library/react';
 
 import VariableBoxContent from './VariableBoxContent';
+import { VartypeEnum } from '../../../shared-types/vartypeEnum';
 
 describe('VariableBoxContent', () => {
   it('should render successfully', () => {
     const { baseElement } = render(
       <VariableBoxContent
         label="test-1"
+        type={VartypeEnum.REGULAR_VARIABLE}
         values={[{ code: 'test-1', label: 'test-1' }]}
         onChangeCodeList={() => {
           return;
@@ -23,7 +25,73 @@ describe('VariableBoxContent', () => {
         totalChosenValues={0}
       />
     );
-    
+
     expect(baseElement).toBeTruthy();
+  });
+
+  it('should render values in order when the type is not time variable', () => {
+    const { baseElement } = render(
+      <VariableBoxContent
+        label="test-1"
+        type={VartypeEnum.REGULAR_VARIABLE}
+        values={[
+          { code: 'test-1', label: 'test-1' },
+          { code: 'test-2', label: 'test-2' },
+        ]}
+        onChangeCodeList={() => {
+          return;
+        }}
+        onChangeCheckbox={() => {
+          return;
+        }}
+        onChangeMixedCheckbox={() => {
+          return;
+        }}
+        varId="test-1"
+        selectedValues={[]}
+        totalValues={2}
+        totalChosenValues={0}
+      />
+    );
+
+    const renderedCheckboxes = getAllByRole(baseElement, 'checkbox');
+
+    // Adds the select all checkbox when more than 1 value is present,
+    // therefore check [1] and [2] instead of [0] and [1]
+    expect(renderedCheckboxes[1].textContent).toBe('Test-1');
+    expect(renderedCheckboxes[2].textContent).toBe('Test-2');
+  });
+
+  it('should render values in reverse order when the type is time variable', () => {
+    const { baseElement } = render(
+      <VariableBoxContent
+        label="test-1"
+        type={VartypeEnum.TIME_VARIABLE}
+        values={[
+          { code: 'test-1', label: 'test-1' },
+          { code: 'test-2', label: 'test-2' },
+        ]}
+        onChangeCodeList={() => {
+          return;
+        }}
+        onChangeCheckbox={() => {
+          return;
+        }}
+        onChangeMixedCheckbox={() => {
+          return;
+        }}
+        varId="test-1"
+        selectedValues={[]}
+        totalValues={2}
+        totalChosenValues={0}
+      />
+    );
+
+    const renderedCheckboxes = getAllByRole(baseElement, 'checkbox');
+
+    // Adds the select all checkbox when more than 1 value is present,
+    // therefore check [1] and [2] instead of [0] and [1]
+    expect(renderedCheckboxes[1].textContent).toBe('Test-2');
+    expect(renderedCheckboxes[2].textContent).toBe('Test-1');
   });
 });

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -8,6 +8,7 @@ import Search from '../../Search/Search';
 import { Select, SelectOption } from '../../Select/Select';
 import { VariableBoxProps } from '../VariableBox';
 import { SelectedVBValues } from '../VariableBox';
+import { VartypeEnum } from '../../../shared-types/vartypeEnum';
 
 type MappedCodeList = {
   value: string;
@@ -35,6 +36,7 @@ type VariableBoxContentProps = VariableBoxPropsToContent & {
 export function VariableBoxContent({
   varId,
   label,
+  type,
   values,
   codeLists,
   selectedValues,
@@ -213,6 +215,14 @@ export function VariableBoxContent({
     (variable) => variable.id === varId
   )?.selectedCodeList;
 
+  const valuesToRender = structuredClone(values);
+
+  //  The API always returns the oldest values first,
+  //  so we can just reverse the values array when the type is TIME_VARIABLE
+  if (type === VartypeEnum.TIME_VARIABLE) {
+    valuesToRender.reverse();
+  }
+
   return (
     <div className={cl(classes['variablebox-content'])}>
       <div className={cl(classes['variablebox-content-main'])}>
@@ -282,7 +292,7 @@ export function VariableBoxContent({
                 text={mixedCheckboxText}
                 value={allValuesSelected}
                 onChange={() => onChangeMixedCheckbox(varId, allValuesSelected)}
-                ariaControls={values.map((value) => value.code)}
+                ariaControls={valuesToRender.map((value) => value.code)}
                 strong={true}
                 inVariableBox={true}
               />
@@ -319,7 +329,7 @@ export function VariableBoxContent({
                 }
               }}
             >
-              {values.map((value) => (
+              {valuesToRender.map((value) => (
                 <Checkbox
                   id={value.code}
                   key={varId + value.code}


### PR DESCRIPTION
Since we want the newest values shown first when a variable is of type 'time variable', we need to reverse the order of the values for that variable, before we render it. This is possible to keep this simple, because the API always returns the oldest values first.

Also added two tests, to check the order of the checkboxes rendered.