### PR TITLE
Fix order of CSS in presentation component

### DIFF
--- a/apps/pxweb2/src/app/components/Presentation/Presentation.module.scss
+++ b/apps/pxweb2/src/app/components/Presentation/Presentation.module.scss
@@ -7,6 +7,17 @@
   background: var(--px-color-surface-default);
   align-self: stretch;
 
+  container-type: inline-size;
+  container-name: contentCont;
+
+  @container contentCont (width > 1px) {
+    .tableContainer {
+      width: 100cqw;
+      overflow-x: auto;
+      scrollbar-width: thin;
+    }
+  }
+
   // xsmall
   @media (min-width: fixed.$breakpoints-xsmall-min-width) and (max-width: fixed.$breakpoints-xsmall-max-width) {
     padding: fixed.$spacing-4;
@@ -31,17 +42,6 @@
   @media ((min-width: fixed.$breakpoints-large-min-width) and (max-width: fixed.$breakpoints-large-max-width)) or ((min-width: fixed.$breakpoints-xlarge-min-width)) {
     padding: fixed.$spacing-10 fixed.$spacing-12;
     gap: fixed.$spacing-10;
-  }
-
-  container-type: inline-size;
-  container-name: contentCont;
-
-  @container contentCont (width > 1px) {
-    .tableContainer {
-      width: 100cqw;
-      overflow-x: auto;
-      scrollbar-width: thin;
-    }
   }
 }
 


### PR DESCRIPTION
The order of the CSS in the presentation component had some media queries before some other code. This counts as having nesting before non-nested CSS, and we get some spam in the console.

"Deprecation Warning: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`."

There is also some other spam in the console about SCSS, but it is not related to this. It seems to be related to some defaults being set in Vite.