### PR TITLE
fix/px-web2-361: Fix languages sv and nor

### DIFF
--- a/apps/pxweb2/public/locales/ar/translation.json
+++ b/apps/pxweb2/public/locales/ar/translation.json
@@ -1,55 +1,82 @@
 {
   "meta": {
-    "languageName": "العربية",
+    "languageName": "إنجليزي",
     "shorthand": "ar"
   },
   "common": {
     "title": "مرحبًا بك في PxWeb 2.0",
     "header": {
-      "title": "PxWeb 2.0",
-      "logo": "PxWeb 2.0"
+      "title": "بيكس ويب 2.0",
+      "logo": "بيكس ويب 2.0"
+    },
+    "footer": {
+      "contact": {
+        "title": "اتصال",
+        "description": "نص الوصف..."
+      },
+      "about": {
+        "title": "عن",
+        "description": "نص الوصف..."
+      },
+      "accessibility": {
+        "title": "إمكانية الوصول",
+        "description": "نص الوصف..."
+      },
+      "version": {
+        "title": "إصدار",
+        "description": "نص الوصف..."
+      }
     },
     "generic_buttons": {
       "ok": "نعم",
       "cancel": "يلغي",
-      "search": "يبحث",
       "save": "يحفظ",
+      "search": "يبحث",
       "close": "يغلق"
+    },
+    "generic_tags": {
+      "mandatory": "إلزامي"
     }
   },
   "start_page": {
     "header": "مرحبا بكم في التطبيق!",
-    "welcome_trans_test": "مرحبًا بك في <1>التطبيق</1> لـ PxWeb 2.0!"
+    "welcome_trans_test": "مرحبا بكم في <1>برنامج</1> لبكسي ويب 2.0!"
   },
   "presentation_page": {
-    "hide": "يخفي",
+    "header": {
+      "searchbutton": "يبحث",
+      "languagebutton": "اللغات",
+      "statistics": "بنك الإحصائيات"
+    },
     "sidemenu": {
+      "hide": "يخفي",
       "selection": {
-        "title": "صفى",
+        "title": "فلتر",
         "variablebox": {
           "search": {
-            "placeholder": "عيب",
-            "label": "عيب",
+            "placeholder": "البحث في القائمة",
+            "label": "يبحث",
             "arialabelicontext": "أيقونة البحث",
-            "ariallabelclearbuttontext": "أيقونة لإزالة النص في حقل البحث"
+            "ariallabelclearbuttontext": "مسح أيقونة البحث"
           },
           "header": {
-            "tag_selected": "تم تحديد {{selected}} من {{total}}",
-            "tag_mandatory": "يجب أن يتم اختياره",
+            "tag_selected": "{{selected}} ل {{total}} مختارة",
+            "tag_mandatory": "إلزامي",
             "alert_no_mandatory_values": "يجب عليك تحديد شيء ما في القائمة حتى يتم عرض الجدول"
           },
           "content": {
             "select": {
-              "label": "اختر القسم",
-              "placeholder": "اختر قسما"
+              "label": "حدد التجميع",
+              "placeholder": "قم بالاختيار",
+              "save": "يحفظ"
             },
             "mixed_checkbox": {
-              "select_all": "اختر الكل",
-              "deselect_all": "الغاء تحديد الكل"
+              "select_all": "حدد الكل",
+              "deselect_all": "قم بإلغاء تحديد الكل"
             },
             "values_list": {
-              "aria_label": "قائمة بقيم {{total}}.",
-              "aria_description": "قائمة المتغير بإجمالي {{total}} القيم. للدخول إلى القائمة، اضغط على مفتاح السهم لأسفل. يخرج المفتاح Tab من القائمة."
+              "aria_label": "قائمة {{total}} قيم.",
+              "aria_description": "قائمة المتغير {{total}} القيم الإجمالية. "
             }
           }
         }
@@ -60,20 +87,62 @@
           "title": "طاولة"
         },
         "graph": {
-          "title": "الرسم البياني"
+          "title": "رسم بياني"
         }
       },
       "edit": {
-        "title": "يحرر"
+        "title": "يحرر",
+        "customize": {
+          "title": "تخصيص",
+          "pivot": {
+            "title": "المحور"
+          },
+          "rearrange": {
+            "title": "إعادة ترتيب الجدول",
+            "description": "نص الوصف..."
+          },
+          "change_order": {
+            "title": "تغيير الترتيب",
+            "description": "نص الوصف..."
+          }
+        },
+        "calculate": {
+          "title": "احسب",
+          "sum": {
+            "title": "مجموع",
+            "description": "نص الوصف..."
+          }
+        },
+        "hide_display": {
+          "title": "إخفاء/إظهار"
+        }
       },
       "save": {
-        "title": "يحفظ"
+        "title": "يحفظ",
+        "file": {
+          "title": "حفظ كملف",
+          "excel": "اكسل (xlsx)"
+        },
+        "imagefile": {
+          "title": "حفظ كرسم بياني",
+          "png": "الرسم البياني (بابوا نيو غينيا)"
+        },
+        "link": {
+          "title": "حفظ كرابط",
+          "description": "نص الوصف..."
+        },
+        "api": {
+          "title": "واجهة برمجة التطبيقات",
+          "description": "نص الوصف..."
+        }
       },
       "help": {
         "title": "يساعد"
       }
     },
     "main_content": {
+      "last_updated": "آخر تحديث",
+      "show_details": "إظهار التفاصيل",
       "table": {
         "warnings": {
           "missing_mandatory": {
@@ -81,7 +150,38 @@
             "description": "يجب عليك تحديد شيء ما في الفلتر"
           }
         }
+      },
+      "about_table": {
+        "title": "حول الطاولة",
+        "footnotes": {
+          "title": "ملحوظات",
+          "show_all_footnotes": "إظهار كافة الملاحظات للجدول"
+        },
+        "information": {
+          "title": "معلومة",
+          "description": "الجدول جزء من الإحصائيات {{statistics}}"
+        },
+        "definition": {
+          "title": "التعاريف",
+          "description": "نص الوصف..."
+        },
+        "metadata": {
+          "title": "البيانات الوصفية",
+          "description": "نص الوصف..."
+        }
+      },
+      "related": {
+        "title": "متعلق ب",
+        "description": "نص الوصف..."
       }
+    },
+    "footer": {
+      "description": "على هذا الموقع، يمكنك متابعة قيام هيئة إحصاءات السويد (SCB) وهيئة إحصاءات النرويج (SSB) ببناء واجهة جديدة وأكثر سهولة في الاستخدام لـ PxWeb.",
+      "descriptionLink": "اقرأ المزيد عن المشروع على جيثب",
+      "contact": "اتصال",
+      "projectLeader": "قائد المشروع",
+      "scrumMaster": "سيد سكروم",
+      "copyright": "حقوق الطبع والنشر © 2024 هيئة إحصاءات السويد وهيئة إحصاءات النرويج"
     }
   }
 }

--- a/apps/pxweb2/public/locales/ar/translation.json
+++ b/apps/pxweb2/public/locales/ar/translation.json
@@ -68,7 +68,10 @@
             "select": {
               "label": "حدد التجميع",
               "placeholder": "قم بالاختيار",
-              "save": "يحفظ"
+              "modal": {
+                "cancel_button": "يلغي",
+                "confirm_button": "يحفظ"
+              }
             },
             "mixed_checkbox": {
               "select_all": "حدد الكل",

--- a/apps/pxweb2/public/locales/en/translation.json
+++ b/apps/pxweb2/public/locales/en/translation.json
@@ -67,7 +67,11 @@
           "content": {
             "select": {
               "label": "Select grouping",
-              "placeholder": "Make a selection"
+              "placeholder": "Make a selection",
+              "modal": {
+                "cancel_button": "Cancel",
+                "confirm_button": "Save"
+              }
             },
             "mixed_checkbox": {
               "select_all": "Select all",

--- a/apps/pxweb2/public/locales/en/translation.json
+++ b/apps/pxweb2/public/locales/en/translation.json
@@ -67,7 +67,7 @@
           "content": {
             "select": {
               "label": "Select grouping",
-              "placeholder": "Make a selection",
+              "placeholder": "Nothing selected",
               "modal": {
                 "cancel_button": "Cancel",
                 "confirm_button": "Save"

--- a/apps/pxweb2/public/locales/no/translation.json
+++ b/apps/pxweb2/public/locales/no/translation.json
@@ -67,7 +67,11 @@
           "content": {
             "select": {
               "label": "Velg inndeling",
-              "placeholder": "Ikke valgt"
+              "placeholder": "Ikke valgt",
+              "modal": {
+                "cancel_button": "Avbryt",
+                "confirm_button": "Bekreft"
+              }
             },
             "mixed_checkbox": {
               "select_all": "Velg alle",

--- a/apps/pxweb2/public/locales/no/translation.json
+++ b/apps/pxweb2/public/locales/no/translation.json
@@ -30,13 +30,13 @@
     "generic_buttons": {
       "ok": "OK",
       "cancel": "Avbryt",
-      "search": "Søk",
       "save": "Lagre",
+      "search": "Søk",
       "close": "Lukk"
+    },
+    "generic_tags": {
+      "mandatory": "Må velges"
     }
-  },
-  "generic_tags": {
-    "mandatory": "Må velges"
   },
   "start_page": {
     "header": "Velkommen til appen!",
@@ -49,12 +49,12 @@
       "statistics": "Statistikkbanken"
     },
     "sidemenu": {
-      "hide": "Skjul meny",
+      "hide": "Skjul",
       "selection": {
         "title": "Filtrer",
         "variablebox": {
           "search": {
-            "placeholder": "Søk",
+            "placeholder": "Søk i listen",
             "label": "Søk",
             "arialabelicontext": "Søkeikon",
             "ariallabelclearbuttontext": "Ikon for å fjerne tekst i søkefeltet"
@@ -67,11 +67,11 @@
           "content": {
             "select": {
               "label": "Velg inndeling",
-              "placeholder": "Velg en inndeling"
+              "placeholder": "Ikke valgt"
             },
             "mixed_checkbox": {
               "select_all": "Velg alle",
-              "deselect_all": "Fjern valgte"
+              "deselect_all": "Fjern alle"
             },
             "values_list": {
               "aria_label": "Liste av {{total}} verdier.",
@@ -173,6 +173,14 @@
         "title": "Relatert",
         "description": "Beskrivelsestekst..."
       }
+    },
+    "footer": {
+      "description": "På denne siden kan du følge med når Statistiska centralbyrån (SCB) og Statistisk sentralbyrå (SSB) bygger et nytt og mer brukervennlig grensesnitt for PxWeb.",
+      "descriptionLink": "Les mer om prosjektet på GitHub",
+      "contact": "Kontakt",
+      "projectLeader": "Prosjektleder",
+      "scrumMaster": "Scrummaster",
+      "copyright": "Opphavsrett © 2024 Statistiska centralbyrån and Statistisk sentralbyrå"
     }
   }
 }

--- a/apps/pxweb2/public/locales/sv/translation.json
+++ b/apps/pxweb2/public/locales/sv/translation.json
@@ -67,7 +67,7 @@
           "content": {
             "select": {
               "label": "Välj indelning",
-              "placeholder": "Välj en division",
+              "placeholder": "Inget valt",
               "modal": {
                 "cancel_button": "Avbryt",
                 "confirm_button": "Spara"

--- a/apps/pxweb2/public/locales/sv/translation.json
+++ b/apps/pxweb2/public/locales/sv/translation.json
@@ -67,7 +67,11 @@
           "content": {
             "select": {
               "label": "Välj indelning",
-              "placeholder": "Välj en division"
+              "placeholder": "Välj en division",
+              "modal": {
+                "cancel_button": "Avbryt",
+                "confirm_button": "Spara"
+              }
             },
             "mixed_checkbox": {
               "select_all": "Välj alla",

--- a/apps/pxweb2/public/locales/sv/translation.json
+++ b/apps/pxweb2/public/locales/sv/translation.json
@@ -30,24 +30,24 @@
     "generic_buttons": {
       "ok": "OK",
       "cancel": "Avbryt",
-      "search": "Sök",
       "save": "Spara",
+      "search": "Sök",
       "close": "Stänga"
     },
     "generic_tags": {
-      "mandatory": "Måste väljas"    
+      "mandatory": "Obligatorisk"
     }
   },
   "start_page": {
     "header": "Välkommen till appen!",
     "welcome_trans_test": "Välkommen till <1>appen</1> för PxWeb 2.0!"
   },
-  "presentation_page": { 
+  "presentation_page": {
     "header": {
-    "searchbutton": "Sök",
-    "languagebutton": "språk",
-    "statistics": "Statistikdatabasen"
-  },
+      "searchbutton": "Sök",
+      "languagebutton": "språk",
+      "statistics": "Statistikdatabasen"
+    },
     "sidemenu": {
       "hide": "Dölj",
       "selection": {
@@ -61,7 +61,7 @@
           },
           "header": {
             "tag_selected": "{{selected}} av {{total}} valda",
-            "tag_mandatory": "Måste väljas",
+            "tag_mandatory": "Obligatorisk",
             "alert_no_mandatory_values": "Du måste välja något i listan för att tabellen ska visas"
           },
           "content": {
@@ -86,7 +86,7 @@
           "title": "Tabell"
         },
         "graph": {
-            "title": "Diagram"
+          "title": "Diagram"
         }
       },
       "edit": {
@@ -106,7 +106,7 @@
           }
         },
         "calculate": {
-          "title": "Beräkna", 
+          "title": "Beräkna",
           "sum": {
             "title": "Summera",
             "description": "Beskrivande text..."
@@ -142,6 +142,14 @@
     "main_content": {
       "last_updated": "Senast uppdaterad",
       "show_details": "Visa detaljer",
+      "table": {
+        "warnings": {
+          "missing_mandatory": {
+            "title": "Tabellen kan inte visas",
+            "description": "Du måste välja något i listan för att tabellen ska visas"
+          }
+        }
+      },
       "about_table": {
         "title": "Om tabellen",
         "footnotes": {
@@ -153,7 +161,7 @@
           "description": "Tabellen är en del av statistiken {{statistics}}"
         },
         "definition": {
-            "title": "Definitioner",
+          "title": "Definitioner",
           "description": "Beskrivande text..."
         },
         "metadata": {
@@ -164,14 +172,6 @@
       "related": {
         "title": "Relaterat",
         "description": "Beskrivande text..."
-      },
-      "table": {
-        "warnings": {
-          "missing_mandatory": {
-            "title": "Tabellen kan inte visas",
-            "description": "Du måste välja något i listan för att tabellen ska visas"
-          }
-        }
       }
     },
     "footer": {

--- a/apps/pxweb2/src/app/components/ContentTop/ContentTop.tsx
+++ b/apps/pxweb2/src/app/components/ContentTop/ContentTop.tsx
@@ -34,7 +34,7 @@ export function ContentTop({ pxtable, staticTitle }: ContenetTopProps) {
         <Heading size="large">{pxtable.metadata.label}</Heading>
         <div className={cl(classes.information)}>
           <Button icon="InformationCircle" variant="secondary">
-            Information
+            {t('presentation_page.main_content.about_table.information.title')}
           </Button>
           {pxtable.metadata && (
             <BodyShort size="medium">

--- a/libs/pxweb2-ui/src/lib/components/Modal/Modal.spec.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Modal/Modal.spec.tsx
@@ -2,29 +2,77 @@ import { render } from '@testing-library/react';
 import Modal from './Modal';
 
 describe('Modal', () => {
-  it('should render successfully', () => {
-    
+  beforeEach(() => {
     // Mock for showModal and close
     if (!window.HTMLDialogElement.prototype.showModal) {
-      window.HTMLDialogElement.prototype.showModal = function() {
-        this.style.display = "block";
-      };
-    }
-    
-    if (!window.HTMLDialogElement.prototype.close) {
-      window.HTMLDialogElement.prototype.close = function() {
-        this.style.display = "none";
+      window.HTMLDialogElement.prototype.showModal = function () {
+        this.style.display = 'block';
       };
     }
 
+    if (!window.HTMLDialogElement.prototype.close) {
+      window.HTMLDialogElement.prototype.close = function () {
+        this.style.display = 'none';
+      };
+    }
+  });
+
+  it('should render successfully', () => {
     const { baseElement } = render(
       <Modal isOpen={true}>
         <span>test</span>
       </Modal>
     );
-    expect(baseElement).toBeTruthy();
 
+    expect(baseElement).toBeTruthy();
   });
 
+  it('should render 3 buttons', () => {
+    const { baseElement } = render(
+      <Modal isOpen={true}>
+        <span>test</span>
+      </Modal>
+    );
 
+    const buttons = baseElement.getElementsByTagName('button');
+    const buttonsLength = buttons.length;
+
+    expect(buttonsLength).toBe(3);
+  });
+
+  it('should render the default button translations', () => {
+    const { baseElement } = render(
+      <Modal isOpen={true}>
+        <span>test</span>
+      </Modal>
+    );
+
+    // Modal has 3 buttons, and the second and third have the text content
+    const buttons = baseElement.getElementsByTagName('button');
+    const saveButton = buttons.item(1);
+    const cancelButton = buttons.item(2);
+
+    expect(saveButton?.textContent).toBe('common.generic_buttons.save');
+    expect(cancelButton?.textContent).toBe('common.generic_buttons.cancel');
+  });
+
+  it('should render the custom button translations', () => {
+    const { baseElement } = render(
+      <Modal
+        isOpen={true}
+        confirmLabel="custom.confirm"
+        cancelLabel="custom.cancel"
+      >
+        <span>test</span>
+      </Modal>
+    );
+
+    // Modal has 3 buttons, and the second and third have the text content
+    const buttons = baseElement.getElementsByTagName('button');
+    const saveButton = buttons.item(1);
+    const cancelButton = buttons.item(2);
+
+    expect(saveButton?.textContent).toBe('custom.confirm');
+    expect(cancelButton?.textContent).toBe('custom.cancel');
+  });
 });

--- a/libs/pxweb2-ui/src/lib/components/Modal/Modal.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Modal/Modal.tsx
@@ -10,6 +10,8 @@ import Button from '../Button/Button';
 export interface ModalProps {
   label?: string;
   heading?: string;
+  cancelLabel?: string;
+  confirmLabel?: string;
   isOpen: boolean;
   onClose?: (updated: boolean) => void;
   className?: string;
@@ -19,6 +21,8 @@ export interface ModalProps {
 export function Modal({
   label,
   heading,
+  cancelLabel = '',
+  confirmLabel = '',
   isOpen,
   onClose,
   className = '',
@@ -28,6 +32,15 @@ export function Modal({
   const cssClasses = className.length > 0 ? ' ' + className : '';
   const [isModalOpen, setModalOpen] = useState(isOpen);
   const modalRef = useRef<HTMLDialogElement | null>(null);
+  let cancelLabelValue = cancelLabel;
+  let confirmLabelValue = confirmLabel;
+
+  if (cancelLabelValue === '') {
+    cancelLabelValue = t('common.generic_buttons.cancel');
+  }
+  if (confirmLabelValue === '') {
+    confirmLabelValue = t('common.generic_buttons.save');
+  }
 
   useEffect(() => {
     setModalOpen(isOpen);
@@ -43,7 +56,7 @@ export function Modal({
         modalElement.close();
         setWindowScroll(true);
       }
-     }
+    }
   }, [isModalOpen]);
 
   const setWindowScroll = (scroll: boolean) => {
@@ -95,7 +108,7 @@ export function Modal({
               size="small"
               icon="XMark"
               onClick={() => handleCloseModal(false)}
-              aria-label={t('common.generic_buttons.cancel')}
+              aria-label={cancelLabelValue}
             ></Button>
           </div>
         </div>
@@ -107,17 +120,17 @@ export function Modal({
             variant="primary"
             size="medium"
             onClick={() => handleCloseModal(true)}
-            aria-label={t('common.generic_buttons.save')}
+            aria-label={confirmLabelValue}
           >
-            {t('common.generic_buttons.save')}
+            {confirmLabelValue}
           </Button>
           <Button
             variant="secondary"
             size="medium"
             onClick={() => handleCloseModal(false)}
-            aria-label={t('common.generic_buttons.cancel')}
+            aria-label={cancelLabelValue}
           >
-            {t('common.generic_buttons.cancel')}
+            {cancelLabelValue}
           </Button>
         </div>
       </div>

--- a/libs/pxweb2-ui/src/lib/components/Select/Select.tsx
+++ b/libs/pxweb2-ui/src/lib/components/Select/Select.tsx
@@ -17,6 +17,8 @@ export type SelectProps = {
   variant?: 'default' | 'inVariableBox';
   label: string;
   modalHeading?: string;
+  modalCancelLabel?: string;
+  modalConfirmLabel?: string;
   hideLabel?: boolean;
   placeholder?: string;
   options: SelectOption[];
@@ -35,6 +37,8 @@ export function Select({
   variant = 'default',
   label,
   modalHeading = '',
+  modalCancelLabel = '',
+  modalConfirmLabel = '',
   hideLabel = false,
   placeholder = '',
   options: ops,
@@ -63,6 +67,8 @@ export function Select({
         <VariableBoxSelect
           label={label}
           modalHeading={modalHeading}
+          modalCancelLabel={modalCancelLabel}
+          modalConfirmLabel={modalConfirmLabel}
           options={ops}
           placeholder={placeholder}
           selectedOption={selectedOption}
@@ -128,7 +134,7 @@ function DefaultSelect({
           size="medium"
           className={cl(classes.optionLayout, classes.optionTypography)}
         >
-         {selectedOption ? selectedOption.label : placeholder}
+          {selectedOption ? selectedOption.label : placeholder}
         </BodyShort>
         <Icon iconName="ChevronDown" className=""></Icon>
       </div>
@@ -140,6 +146,8 @@ type VariableBoxSelectProps = Pick<
   SelectProps,
   | 'label'
   | 'modalHeading'
+  | 'modalCancelLabel'
+  | 'modalConfirmLabel'
   | 'options'
   | 'placeholder'
   | 'selectedOption'
@@ -151,6 +159,8 @@ type VariableBoxSelectProps = Pick<
 function VariableBoxSelect({
   label,
   modalHeading,
+  modalCancelLabel,
+  modalConfirmLabel,
   options,
   placeholder,
   selectedOption,
@@ -161,17 +171,17 @@ function VariableBoxSelect({
   const cssClasses = className.length > 0 ? ' ' + className : '';
 
   const [isModalOpen, setModalOpen] = useState<boolean>(false);
-  
+
   const [selectedItem, setSelectedItem] = useState<SelectOption | undefined>(
     selectedOption
   );
-  const [clickedItem, setClickedItem] = useState<SelectOption | undefined>(   
+  const [clickedItem, setClickedItem] = useState<SelectOption | undefined>(
     selectedOption
   );
   const handleOpenModal = () => {
     setModalOpen(true);
   };
-  
+
   function handleRadioChange(e: React.ChangeEvent<HTMLInputElement>) {
     setClickedItem(options.find((option) => option.value === e.target.value));
   }
@@ -181,8 +191,7 @@ function VariableBoxSelect({
     if (updated) {
       setSelectedItem(clickedItem);
       onChange(clickedItem);
-    }
-    else {
+    } else {
       setClickedItem(selectedItem);
     }
   };
@@ -222,6 +231,8 @@ function VariableBoxSelect({
         <Modal
           label={label}
           heading={modalHeading}
+          cancelLabel={modalCancelLabel}
+          confirmLabel={modalConfirmLabel}
           isOpen={isModalOpen}
           onClose={handleCloseModal}
         >

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -274,6 +274,12 @@ export function VariableBoxContent({
                 'presentation_page.sidemenu.selection.variablebox.content.select.label'
               )}
               modalHeading={label}
+              modalCancelLabel={t(
+                'presentation_page.sidemenu.selection.variablebox.content.select.modal.cancel_button'
+              )}
+              modalConfirmLabel={t(
+                'presentation_page.sidemenu.selection.variablebox.content.select.modal.confirm_button'
+              )}
               placeholder={t(
                 'presentation_page.sidemenu.selection.variablebox.content.select.placeholder'
               )}


### PR DESCRIPTION
The translations are a bit out of date, and not correct. This should fix this for all 4 translations files. I have only fixed existing translation keys in the application, and have not added any new translations from the confluence page.

I also expanded on the Modal and Select to be able to provide custom translations for the Modal buttons, since it used the `generic_buttons` translations, which do not have the same meaning in the Norwegian translation. This was only for the VariableBox.
```
EN = Save
NOR = Bekreft (confirm)
```

Important: The arabic translation file was very out of date, with many missing translations. This has been fixed with https://translate.i18next.com/, which uses google translate. It is not meant for any production use! We would need to do proper translations at a later point for that.