### PR TITLE
Fix for checkbox order in variablebox when time

### DIFF
--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -99,7 +99,7 @@ export function VariableBoxContent({
       newItems.push({ type: 'mixedCheckbox' });
     }
 
-    values
+    valuesToRender
       .filter(
         (value) =>
           value.label.toLowerCase().indexOf(debouncedSearch.toLowerCase()) > -1
@@ -109,6 +109,8 @@ export function VariableBoxContent({
       });
 
     setItems(newItems);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasSevenOrMoreValues, hasTwoOrMoreValues, debouncedSearch, values]);
 
   useEffect(() => {


### PR DESCRIPTION
This fix reimplements the right order for the checkboxes in the VariableBox. It does not fix the tests, where two were commented out when Virtuoso was implemented. There is another task in the backlog for fixing them.