### PR TITLE
Feature/Add showing the codelist from the defaultSelection in the VariableBoxes

### DIFF
--- a/apps/pxweb2/src/app/components/Selection/Selection.tsx
+++ b/apps/pxweb2/src/app/components/Selection/Selection.tsx
@@ -10,6 +10,7 @@ import {
   VariableList,
   Value,
   SelectOption,
+  mapCodeListToSelectOption,
 } from '@pxweb2/pxweb2-ui';
 import NavigationDrawer from '../../components/NavigationDrawer/NavigationDrawer';
 import useVariables from '../../context/useVariables';
@@ -26,7 +27,7 @@ function addSelectedCodeListToVariable(
   if (currentVariable) {
     newSelectedValues = selectedValuesArr.map((variable) => {
       if (variable.id === varId) {
-        variable.selectedCodeList = selectedItem;
+        variable.selectedCodeList = selectedItem.value;
         variable.values = []; // Always reset values when changing codelist
       }
 
@@ -38,7 +39,7 @@ function addSelectedCodeListToVariable(
       ...selectedValuesArr,
       {
         id: varId,
-        selectedCodeList: selectedItem,
+        selectedCodeList: selectedItem.value,
         values: [],
       },
     ];
@@ -258,34 +259,45 @@ export function Selection({
     varId: string
   ) {
     const prevSelectedValues = structuredClone(selectedVBValues);
+    const currentVariableMetadata = pxTableMetaToRender?.variables.find(
+      (variable) => variable.id === varId
+    );
     const currentVariable = prevSelectedValues.find(
       (variable) => variable.id === varId
     );
+    const currentCodeList = currentVariable?.selectedCodeList;
 
     // No new selection made, do nothing
-    if (
-      !selectedItem ||
-      selectedItem.value === currentVariable?.selectedCodeList?.value
-    ) {
-      return;
-    }
-    //  Incomplete selectItem
-    if (!selectedItem.label || !selectedItem.value) {
+    if (!selectedItem || selectedItem.value === currentCodeList) {
       return;
     }
 
+    if (pxTableMetaToRender === null) {
+      return;
+    }
+
+    const newSelectedCodeList = currentVariableMetadata?.codeLists?.find(
+      (codelist) => codelist.id === selectedItem.value
+    );
+
+    if (!newSelectedCodeList) {
+      return;
+    }
+
+    const newMappedSelectedCodeList =
+      mapCodeListToSelectOption(newSelectedCodeList);
     const newSelectedValues = addSelectedCodeListToVariable(
       currentVariable,
       prevSelectedValues,
       varId,
-      selectedItem
+      newMappedSelectedCodeList
     );
 
     updateAndSyncVBValues(newSelectedValues);
 
     //  TODO: This currently returns dummy data until we have the API call setup for it
     const valuesForChosenCodeList: Value[] = getCodeListValues(
-      selectedItem?.value
+      newMappedSelectedCodeList.value
     );
 
     if (pxTableMetaToRender === null || valuesForChosenCodeList.length < 1) {
@@ -300,7 +312,7 @@ export function Selection({
       }
 
       variable.codeLists.forEach((codelist) => {
-        if (codelist.id !== selectedItem?.value) {
+        if (codelist.id !== newMappedSelectedCodeList.value) {
           return;
         }
 

--- a/apps/pxweb2/src/app/context/VariablesProvider.tsx
+++ b/apps/pxweb2/src/app/context/VariablesProvider.tsx
@@ -97,17 +97,19 @@ export const VariablesProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // not in use so far, but maybe to use it in TableDataProvdider when update Cube.
   const getSelectedValuesByIdSorted = (variableId: string) => {
-    let sortedValues:string[] =[] 
+    let sortedValues: string[] = [];
     pxTableMetadata?.variables.forEach((item) => {
       if (item.id === variableId) {
-        sortedValues = (item.values.filter((value) =>
-          selectedVBValues.find(
-            (selvar) => selvar.id === variableId
-          )?.values.includes(value.code)).map(value=>value.code)
-        );
+        sortedValues = item.values
+          .filter((value) =>
+            selectedVBValues
+              .find((selvar) => selvar.id === variableId)
+              ?.values.includes(value.code)
+          )
+          .map((value) => value.code);
       }
     });
-    return sortedValues
+    return sortedValues;
   };
 
   const getNumberOfSelectedValues = () => {

--- a/apps/pxweb2/src/mappers/TableSelectionResponseMapper.spec.ts
+++ b/apps/pxweb2/src/mappers/TableSelectionResponseMapper.spec.ts
@@ -15,6 +15,7 @@ describe('TableSelectionResponseMapper', () => {
             },
             {
               variableCode: 'testVarCode2',
+              codeList: 'testCodeList',
               valueCodes: ['testValueCode2'],
             },
           ],
@@ -32,7 +33,7 @@ describe('TableSelectionResponseMapper', () => {
         },
         {
           id: 'testVarCode2',
-          selectedCodeList: undefined,
+          selectedCodeList: 'testCodeList',
           values: ['testValueCode2'],
         },
       ]);

--- a/apps/pxweb2/src/mappers/TableSelectionResponseMapper.ts
+++ b/apps/pxweb2/src/mappers/TableSelectionResponseMapper.ts
@@ -1,21 +1,21 @@
 import { SelectionResponse } from '@pxweb2/pxweb2-api-client';
 import { SelectedVBValues } from '@pxweb2/pxweb2-ui';
 
+type VariableWithoutCodelist = Omit<SelectedVBValues, 'selectedCodeList'>;
+type VariableWithCodelistValue = VariableWithoutCodelist & {
+  selectedCodeList: string | undefined;
+};
+
 export function mapTableSelectionResponse(
   response: SelectionResponse
-): SelectedVBValues[] {
-  // TODO:  Check if selection.selection is intended,
-  const selectedVBValues: SelectedVBValues[] = response.selection.selection.map(
-    (variable) => {
+): VariableWithCodelistValue[] {
+  const selectedVBValues: VariableWithCodelistValue[] =
+    response.selection.selection.map((variable) => {
       return {
         id: variable.variableCode,
-
-        // TODO: Not ready in the API yet, implement when ready
-        //       handleCodeListChange in app.tsx probably needs to be refactored for this to work optimally
-        selectedCodeList: undefined,
+        selectedCodeList: variable.codeList ? variable.codeList : undefined,
         values: variable.valueCodes ? variable.valueCodes : [],
       };
-    }
-  );
+    });
   return selectedVBValues;
 }

--- a/libs/pxweb2-ui/src/index.ts
+++ b/libs/pxweb2-ui/src/index.ts
@@ -28,5 +28,6 @@ export * from './lib/shared-types/pxTableData';
 export * from './lib/shared-types/value';
 export * from './lib/shared-types/variable';
 export * from './lib/shared-types/vartypeEnum';
+export * from './lib/util/util';
 export * from './../style-dictionary/dist/js/css-variables';
 export * from './../style-dictionary/dist/js/fixed-variables';

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBox.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBox.tsx
@@ -10,7 +10,7 @@ import { Value } from '../../shared-types/value';
 
 export type SelectedVBValues = {
   id: string;
-  selectedCodeList: SelectOption | undefined;
+  selectedCodeList: string | undefined;
   values: Value['code'][];
 };
 

--- a/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/libs/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import cl from 'clsx';
 import { useTranslation } from 'react-i18next';
+import { useDebounce } from '@uidotdev/usehooks';
+import { Virtuoso } from 'react-virtuoso';
 
 import classes from './VariableBoxContent.module.scss';
 import { Checkbox, MixedCheckbox } from '../../Checkbox/Checkbox';
@@ -9,15 +11,10 @@ import { Select, SelectOption } from '../../Select/Select';
 import { VariableBoxProps } from '../VariableBox';
 import { SelectedVBValues } from '../VariableBox';
 import { VartypeEnum } from '../../../shared-types/vartypeEnum';
-import { Virtuoso } from 'react-virtuoso';
 import { Value } from '../../../shared-types/value';
-import { useDebounce } from '@uidotdev/usehooks';
 import Skeleton from '../../Skeleton/Skeleton';
+import { mapCodeListsToSelectOptions } from '../../../util/util';
 
-type MappedCodeList = {
-  value: string;
-  label: string;
-};
 type VariableBoxPropsToContent = Omit<
   VariableBoxProps,
   'id' | 'mandatory' | 'tableId'
@@ -133,16 +130,20 @@ export function VariableBoxContent({
     checkboxDeselectAllText,
   ]);
 
-  let mappedCodeList: MappedCodeList[] = [];
+  let mappedCodeLists: SelectOption[] = [];
 
   if (hasCodeLists === true) {
-    mappedCodeList = codeLists?.map((codeList) => {
-      return {
-        value: codeList.id,
-        label: codeList.label,
-      };
-    });
+    mappedCodeLists = mapCodeListsToSelectOptions(codeLists);
   }
+
+  // needs the selected, mapped code list for the current variable
+  const currentVarSelectedCodeListId = selectedValues.find(
+    (variable) => variable.id === varId
+  )?.selectedCodeList;
+  const selectedCodeListMapped = mappedCodeLists.find(
+    (codeList) => codeList.value === currentVarSelectedCodeListId
+  );
+  const selectedCodeListOrUndefined = selectedCodeListMapped ?? undefined;
 
   const handleValueListKeyboardNavigation = (
     event: React.KeyboardEvent<HTMLDivElement>
@@ -186,16 +187,11 @@ export function VariableBoxContent({
       if (elementId) {
         const element = document.getElementById(elementId);
         if (element) {
-          console.log('focused on this', element);
           element.focus();
         }
       }
     }
   };
-
-  const currentVarSelectedCodeList = selectedValues.find(
-    (variable) => variable.id === varId
-  )?.selectedCodeList;
 
   // Modify the itemRenderer to assign IDs and tabIndex
   const itemRenderer = (items: any, index: number) => {
@@ -285,12 +281,8 @@ export function VariableBoxContent({
               placeholder={t(
                 'presentation_page.sidemenu.selection.variablebox.content.select.placeholder'
               )}
-              options={mappedCodeList}
-              selectedOption={
-                currentVarSelectedCodeList
-                  ? currentVarSelectedCodeList
-                  : undefined
-              }
+              options={mappedCodeLists}
+              selectedOption={selectedCodeListOrUndefined}
               onChange={(selectedItem) => onChangeCodeList(selectedItem, varId)}
             />
           </div>

--- a/libs/pxweb2-ui/src/lib/util/util.ts
+++ b/libs/pxweb2-ui/src/lib/util/util.ts
@@ -1,5 +1,25 @@
+import { CodeList } from '../shared-types/codelist';
+import { SelectOption } from '../components/Select/Select';
+
 export const getCSSVariable = (variable: string): string => {
   const rootStyle = getComputedStyle(document.documentElement);
   const cssVar = rootStyle.getPropertyValue(variable).trim(); // Remove whitespace at beginning of string
   return cssVar;
+};
+
+export const mapCodeListToSelectOption = (
+  codeList: CodeList
+): SelectOption => ({
+  label: codeList.label,
+  value: codeList.id,
+});
+
+// return array of SelectOption objects
+export const mapCodeListsToSelectOptions = (
+  codeList: CodeList[]
+): SelectOption[] => {
+  return codeList.map((code) => ({
+    label: code.label,
+    value: code.id,
+  }));
 };


### PR DESCRIPTION
Since the API now supports a default codelist in the defaultSelection of a table, we need the implementation for showing this when loading a table.

This work was started as part of PxWeb2-198, but was moved to it's own task and branch. Any remaining cleanup will be done during that task.