### PR TITLE
Update the API-query for the metadata

### DIFF
--- a/apps/pxweb2/src/app/components/Selection/Selection.tsx
+++ b/apps/pxweb2/src/app/components/Selection/Selection.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useState, useEffect } from 'react';
 
-import { TableService } from '@pxweb2/pxweb2-api-client';
+import { metadataOutputFormat, MetadataOutputFormatType, TableService } from '@pxweb2/pxweb2-api-client';
 import { mapTableMetadataResponse } from '../../../mappers/TableMetadataResponseMapper';
 import { mapTableSelectionResponse } from '../../../mappers/TableSelectionResponseMapper';
 import {
@@ -211,11 +211,15 @@ export function Selection({
       variables.setIsLoadingMetadata(true);
     }
 
-    TableService.getMetadataById(selectedTabId, i18n.resolvedLanguage)
+    const outputFormat: metadataOutputFormat = MetadataOutputFormatType.JSON_PX;
+    const metaDataDefaultSelection = true;
+    
+    TableService.getMetadataById(selectedTabId, i18n.resolvedLanguage, outputFormat, metaDataDefaultSelection)
       .then((tableMetadataResponse) => {
         const pxTabMetadata: PxTableMetadata = mapTableMetadataResponse(
           tableMetadataResponse
         );
+        
         setPxTableMetadata(pxTabMetadata);
         if (pxTableMetaToRender !== null) {
           setPxTableMetaToRender(null);

--- a/apps/pxweb2/src/mappers/TableMetadataResponseMapper.ts
+++ b/apps/pxweb2/src/mappers/TableMetadataResponseMapper.ts
@@ -1,59 +1,78 @@
-import { AbstractCodeListVariable, TableMetadataResponse, VariableTypeEnum } from "@pxweb2/pxweb2-api-client";
-import { PxTableMetadata, VartypeEnum } from "@pxweb2/pxweb2-ui";
+import {
+  AbstractCodeListVariable,
+  TableMetadataResponse,
+  VariableTypeEnum,
+} from '@pxweb2/pxweb2-api-client';
+import { PxTableMetadata, VartypeEnum } from '@pxweb2/pxweb2-ui';
 
-export function mapTableMetadataResponse(response: TableMetadataResponse): PxTableMetadata {
-
+export function mapTableMetadataResponse(
+  response: TableMetadataResponse
+): PxTableMetadata {
+  try {
     const pxTableMetadata: PxTableMetadata = {
-        id: response.id,
-        label: response.label,
-        updated: response.updated ? new Date(response.updated) : new Date(),
-        variables: response.variables.map((variable) => {
+      id: response.id,
+      label: response.label,
+      updated: response.updated ? new Date(response.updated) : new Date(),
+      variables: response.variables.map((variable) => {
+        return {
+          id: variable.id,
+          label: variable.label,
+          type: mapVariableTypeEnum(variable.type),
+          mandatory:
+            (variable as AbstractCodeListVariable).elimination != null
+              ? !(variable as AbstractCodeListVariable).elimination
+              : true,
+          values: (variable as AbstractCodeListVariable).values.map((value) => {
             return {
-                id: variable.id,
-                label: variable.label,
-                type: mapVariableTypeEnum(variable.type),
-                mandatory: (variable as AbstractCodeListVariable).elimination != null ? !(variable as AbstractCodeListVariable).elimination : true,
-                values: (variable as AbstractCodeListVariable).values.map((value) => {
-                    return {
-                        label: value.label,
-                        code: value.code,
-                        notes: value.notes?.map((note) => {
-                            return {
-                                text: note.text,
-                                mandatory: note.mandatory != null ? note.mandatory : false
-                            };
-                        })
-                    };
-                }),
-                codeLists: (variable as AbstractCodeListVariable).codeLists?.map((codeList) => {
-                    return {
-                        id: codeList.id,
-                        label: codeList.label,
-                    };
-                }),
-                notes: variable.notes?.map((note) => {
-                    return {
-                        text: note.text,
-                        mandatory: note.mandatory != null ? note.mandatory : false
-                    };
-                })
+              label: value.label,
+              code: value.code,
+              notes: value.notes?.map((note) => {
+                return {
+                  text: note.text,
+                  mandatory: note.mandatory != null ? note.mandatory : false,
+                };
+              }),
             };
-        }),
-        language: ""
+          }),
+          codeLists: (variable as AbstractCodeListVariable).codeLists?.map(
+            (codeList) => {
+              return {
+                id: codeList.id,
+                label: codeList.label,
+              };
+            }
+          ),
+          notes: variable.notes?.map((note) => {
+            return {
+              text: note.text,
+              mandatory: note.mandatory != null ? note.mandatory : false,
+            };
+          }),
+        };
+      }),
+      language: '',
     };
 
     return pxTableMetadata;
+  } catch (error) {
+    console.error('Error mapping table metadata response', error);
+    throw new Error('Error mapping table metadata response');
+  }
 }
 
 function mapVariableTypeEnum(type: VariableTypeEnum): VartypeEnum {
-    switch (type) {
-        case VariableTypeEnum.CONTENTS_VARIABLE:
-            return VartypeEnum.CONTENTS_VARIABLE;
-        case VariableTypeEnum.TIME_VARIABLE:
-            return VartypeEnum.TIME_VARIABLE;
-        case VariableTypeEnum.GEOGRAPHICAL_VARIABLE:
-            return VartypeEnum.GEOGRAPHICAL_VARIABLE;
-        case VariableTypeEnum.REGULAR_VARIABLE:
-            return VartypeEnum.REGULAR_VARIABLE;
-    }
+  switch (type) {
+    case VariableTypeEnum.CONTENTS_VARIABLE:
+      return VartypeEnum.CONTENTS_VARIABLE;
+    case VariableTypeEnum.TIME_VARIABLE:
+      return VartypeEnum.TIME_VARIABLE;
+    case VariableTypeEnum.GEOGRAPHICAL_VARIABLE:
+      return VartypeEnum.GEOGRAPHICAL_VARIABLE;
+    case VariableTypeEnum.REGULAR_VARIABLE:
+      return VartypeEnum.REGULAR_VARIABLE;
+    default:
+      throw new Error(
+        `Unknown variable type in mapTableMetadataResponse: ${type}`
+      );
+  }
 }

--- a/libs/pxweb2-api-client/src/index.ts
+++ b/libs/pxweb2-api-client/src/index.ts
@@ -71,6 +71,7 @@ export { TimeVariable } from './models/TimeVariable';
 export type { updated } from './models/updated';
 export type { Value } from './models/Value';
 export type { ValueMap } from './models/ValueMap';
+export type { VariablePlacementType } from './models/VariablePlacementType';
 export type { VariableSelection } from './models/VariableSelection';
 export type { VariablesSelection } from './models/VariablesSelection';
 export { VariableTypeEnum } from './models/VariableTypeEnum';

--- a/libs/pxweb2-api-client/src/models/ConfigResponse.ts
+++ b/libs/pxweb2-api-client/src/models/ConfigResponse.ts
@@ -11,9 +11,13 @@ import type { SourceReference } from './SourceReference';
  */
 export type ConfigResponse = {
     /**
-     * The version of then API
+     * The version of the API spesification
      */
     apiVersion: string;
+    /**
+     * The version of the API implementation
+     */
+    appVersion: string;
     /**
      * A list of language that exists for the data.
      */

--- a/libs/pxweb2-api-client/src/models/VariablePlacementType.ts
+++ b/libs/pxweb2-api-client/src/models/VariablePlacementType.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type VariablePlacementType = {
+    /**
+     * List of variables that should be placed in the heading in the resulting data
+     */
+    heading?: Array<string>;
+    /**
+     * List of variables that should be placed in the stub in the resulting data
+     */
+    stub?: Array<string>;
+};
+

--- a/libs/pxweb2-api-client/src/models/VariablesSelection.ts
+++ b/libs/pxweb2-api-client/src/models/VariablesSelection.ts
@@ -2,8 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { VariablePlacementType } from './VariablePlacementType';
 import type { VariableSelection } from './VariableSelection';
 export type VariablesSelection = {
     selection: Array<VariableSelection>;
+    palcement?: VariablePlacementType;
 };
 

--- a/libs/pxweb2-api-client/src/services/TableService.ts
+++ b/libs/pxweb2-api-client/src/services/TableService.ts
@@ -14,234 +14,245 @@ import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 export class TableService {
-  /**
-   * Get all Tables.
-   * @param lang The language if the default is not what you want.
-   * @param query Selects only tables that that matches a criteria which is specified by the search parameter.
-   * @param pastDays Selects only tables that was updated from the time of execution going back number of days stated by the parameter pastDays. Valid values for past days are integers between 1 and ?
-   * @param includeDiscontinued Decides if discontinued tables are included in response.
-   * @param pageNumber Pagination: Decides which page number to return
-   * @param pageSize Pagination: Decides how many tables per page
-   * @returns TablesResponse Success
-   * @throws ApiError
-   */
-  public static listAllTables(
-    lang?: string | null,
-    query?: string,
-    pastDays?: number,
-    includeDiscontinued: boolean = false,
-    pageNumber: number = 1,
-    pageSize?: number
-  ): CancelablePromise<TablesResponse> {
-    return __request(OpenAPI, {
-      method: 'GET',
-      url: '/tables',
-      query: {
-        lang: lang,
-        query: query,
-        pastDays: pastDays,
-        includeDiscontinued: includeDiscontinued,
-        pageNumber: pageNumber,
-        pageSize: pageSize,
-      },
-    });
-  }
-  /**
-   * Get Table by {id}.
-   * @param id Id
-   * @param lang The language if the default is not what you want.
-   * @returns TableResponse Success
-   * @throws ApiError
-   */
-  public static getTableById(
-    id: string,
-    lang?: string | null
-  ): CancelablePromise<TableResponse> {
-    return __request(OpenAPI, {
-      method: 'GET',
-      url: '/tables/{id}',
-      path: {
-        id: id,
-      },
-      query: {
-        lang: lang,
-      },
-      errors: {
-        400: `Error respsone for 400`,
-        404: `Error respsone for 404`,
-        429: `Error respsone for 429`,
-      },
-    });
-  }
-  /**
-   * Get Metadata about Table by {id}.
-   * **Used for listing detailed information about a specific table**
-   * * List all variables and values and all other metadata needed to be able to fetch data
-   *
-   * * Also links to where to:
-   * + Fetch
-   * - Where to get information about codelists
-   *
-   * * 2 output formats
-   * + Custom json
-   * - JSON-stat2
-   *
-   * @param id Id
-   * @param lang The language if the default is not what you want.
-   * @param outputFormat The format of the resulting metadata
-   * @returns TableMetadataResponse Success
-   * @throws ApiError
-   */
-  public static getMetadataById(
-    id: string,
-    lang?: string | null,
-    outputFormat?: MetadataOutputFormatType
-  ): CancelablePromise<TableMetadataResponse> {
-    return __request(OpenAPI, {
-      method: 'GET',
-      url: '/tables/{id}/metadata',
-      path: {
-        id: id,
-      },
-      query: {
-        lang: lang,
-        outputFormat: outputFormat,
-      },
-      errors: {
-        400: `Error respsone for 400`,
-        404: `Error respsone for 404`,
-        429: `Error respsone for 429`,
-      },
-    });
-  }
-  /**
-   * Get the default selection for Table by {id}.
-   * Get information about what is selected for the table by default when no selection is made i the /data endpoint.
-   * @param id Id
-   * @param lang The language if the default is not what you want.
-   * @returns SelectionResponse Success
-   * @throws ApiError
-   */
-  public static getDefaultSelection(
-    id: string,
-    lang?: string | null
-  ): CancelablePromise<SelectionResponse> {
-    return __request(OpenAPI, {
-      method: 'GET',
-      url: '/tables/{id}/defaultselection',
-      path: {
-        id: id,
-      },
-      query: {
-        lang: lang,
-      },
-      errors: {
-        400: `Error respsone for 400`,
-        404: `Error respsone for 404`,
-        429: `Error respsone for 429`,
-      },
-    });
-  }
-  /**
-   * Get Codelist by {id}.
-   * @param id Id
-   * @param lang The language if the default is not what you want.
-   * @returns CodeListResponse Success
-   * @throws ApiError
-   */
-  public static getTableCodeListById(
-    id: string,
-    lang?: string | null
-  ): CancelablePromise<CodeListResponse> {
-    return __request(OpenAPI, {
-      method: 'GET',
-      url: '/codelists/{id}',
-      path: {
-        id: id,
-      },
-      query: {
-        lang: lang,
-      },
-      errors: {
-        400: `Error respsone for 400`,
-        404: `Error respsone for 404`,
-        429: `Error respsone for 429`,
-      },
-    });
-  }
-  /**
-   * Get data from table by {id}.
-   * @param id Id
-   * @param lang The language if the default is not what you want.
-   * @param valuecodes
-   * @param codelist
-   * @param outputvalues
-   * @param outputFormat
-   * @returns string Success
-   * @throws ApiError
-   */
-  public static getTableData(
-    id: string,
-    lang?: string | null,
-    valuecodes?: Record<string, Array<string>>,
-    codelist?: Record<string, string>,
-    outputvalues?: Record<string, CodeListOutputValuesType>,
-    outputFormat?: string
-  ): CancelablePromise<string> {
-    return __request(OpenAPI, {
-      method: 'GET',
-      url: '/tables/{id}/data',
-      path: {
-        id: id,
-      },
-      query: {
-        lang: lang,
-        valuecodes: valuecodes,
-        codelist: codelist,
-        outputvalues: outputvalues,
-        outputFormat: outputFormat,
-      },
-      errors: {
-        400: `Error respsone for 400`,
-        403: `Error respsone for 403`,
-        404: `Error respsone for 404`,
-        429: `Error respsone for 429`,
-      },
-    });
-  }
-  /**
-   * Get data from table by {id}.
-   * @param id Id
-   * @param lang The language if the default is not what you want.
-   * @param outputFormat
-   * @param requestBody A selection
-   * @returns string Success
-   * @throws ApiError
-   */
-  public static getTableDataByPost(
-    id: string,
-    lang?: string | null,
-    outputFormat?: string,
-    requestBody?: VariablesSelection
-  ): CancelablePromise<string> {
-    return __request(OpenAPI, {
-      method: 'POST',
-      url: '/tables/{id}/data',
-      path: {
-        id: id,
-      },
-      query: {
-        lang: lang,
-        outputFormat: outputFormat,
-      },
-      body: requestBody,
-      mediaType: 'application/json',
-      errors: {
-        400: `Error respsone for 400`,
-        403: `Error respsone for 403`,
-        404: `Error respsone for 404`,
-        429: `Error respsone for 429`,
-      },
-    });
-  }
+    /**
+     * Get all Tables.
+     * @param lang The language if the default is not what you want.
+     * @param query Selects only tables that that matches a criteria which is specified by the search parameter.
+     * @param pastDays Selects only tables that was updated from the time of execution going back number of days stated by the parameter pastDays. Valid values for past days are integers between 1 and ?
+     * @param includeDiscontinued Decides if discontinued tables are included in response.
+     * @param pageNumber Pagination: Decides which page number to return
+     * @param pageSize Pagination: Decides how many tables per page
+     * @returns TablesResponse Success
+     * @throws ApiError
+     */
+    public static listAllTables(
+        lang?: string | null,
+        query?: string,
+        pastDays?: number,
+        includeDiscontinued: boolean = false,
+        pageNumber: number = 1,
+        pageSize?: number,
+    ): CancelablePromise<TablesResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/tables',
+            query: {
+                'lang': lang,
+                'query': query,
+                'pastDays': pastDays,
+                'includeDiscontinued': includeDiscontinued,
+                'pageNumber': pageNumber,
+                'pageSize': pageSize,
+            },
+        });
+    }
+    /**
+     * Get Table by {id}.
+     * @param id Id
+     * @param lang The language if the default is not what you want.
+     * @returns TableResponse Success
+     * @throws ApiError
+     */
+    public static getTableById(
+        id: string,
+        lang?: string | null,
+    ): CancelablePromise<TableResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/tables/{id}',
+            path: {
+                'id': id,
+            },
+            query: {
+                'lang': lang,
+            },
+            errors: {
+                400: `Error respsone for 400`,
+                404: `Error respsone for 404`,
+                429: `Error respsone for 429`,
+            },
+        });
+    }
+    /**
+     * Get Metadata about Table by {id}.
+     * **Used for listing detailed information about a specific table**
+     * * List all variables and values and all other metadata needed to be able to fetch data
+     *
+     * * Also links to where to:
+     * + Fetch
+     * - Where to get information about codelists
+     *
+     * * 2 output formats
+     * + Custom json
+     * - JSON-stat2
+     *
+     * @param id Id
+     * @param lang The language if the default is not what you want.
+     * @param outputFormat The format of the resulting metadata
+     * @param defaultSelection If metadata should be included as if default selection would have been applied.
+     * This is a technical parameter that is used by PxWeb for initial loading of tables.
+     *
+     * @returns TableMetadataResponse Success
+     * @throws ApiError
+     */
+    public static getMetadataById(
+        id: string,
+        lang?: string | null,
+        outputFormat?: MetadataOutputFormatType,
+        defaultSelection: boolean = false,
+    ): CancelablePromise<TableMetadataResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/tables/{id}/metadata',
+            path: {
+                'id': id,
+            },
+            query: {
+                'lang': lang,
+                'outputFormat': outputFormat,
+                'defaultSelection': defaultSelection,
+            },
+            errors: {
+                400: `Error respsone for 400`,
+                404: `Error respsone for 404`,
+                429: `Error respsone for 429`,
+            },
+        });
+    }
+    /**
+     * Get the default selection for Table by {id}.
+     * Get information about what is selected for the table by default when no selection is made i the /data endpoint.
+     * @param id Id
+     * @param lang The language if the default is not what you want.
+     * @returns SelectionResponse Success
+     * @throws ApiError
+     */
+    public static getDefaultSelection(
+        id: string,
+        lang?: string | null,
+    ): CancelablePromise<SelectionResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/tables/{id}/defaultselection',
+            path: {
+                'id': id,
+            },
+            query: {
+                'lang': lang,
+            },
+            errors: {
+                400: `Error respsone for 400`,
+                404: `Error respsone for 404`,
+                429: `Error respsone for 429`,
+            },
+        });
+    }
+    /**
+     * Get Codelist by {id}.
+     * @param id Id
+     * @param lang The language if the default is not what you want.
+     * @returns CodeListResponse Success
+     * @throws ApiError
+     */
+    public static getTableCodeListById(
+        id: string,
+        lang?: string | null,
+    ): CancelablePromise<CodeListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/codelists/{id}',
+            path: {
+                'id': id,
+            },
+            query: {
+                'lang': lang,
+            },
+            errors: {
+                400: `Error respsone for 400`,
+                404: `Error respsone for 404`,
+                429: `Error respsone for 429`,
+            },
+        });
+    }
+    /**
+     * Get data from table by {id}.
+     * @param id Id
+     * @param lang The language if the default is not what you want.
+     * @param valuecodes
+     * @param codelist
+     * @param outputvalues
+     * @param outputFormat
+     * @param heading Commaseparated list of variable codes that should be placed in the heading in the resulting data
+     * @param stub Commaseparated list of variable codes that should be placed in the stub in the resulting data
+     * @returns string Success
+     * @throws ApiError
+     */
+    public static getTableData(
+        id: string,
+        lang?: string | null,
+        valuecodes?: Record<string, Array<string>>,
+        codelist?: Record<string, string>,
+        outputvalues?: Record<string, CodeListOutputValuesType>,
+        outputFormat?: string,
+        heading?: Array<string>,
+        stub?: Array<string>,
+    ): CancelablePromise<string> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/tables/{id}/data',
+            path: {
+                'id': id,
+            },
+            query: {
+                'lang': lang,
+                'valuecodes': valuecodes,
+                'codelist': codelist,
+                'outputvalues': outputvalues,
+                'outputFormat': outputFormat,
+                'heading': heading,
+                'stub': stub,
+            },
+            errors: {
+                400: `Error respsone for 400`,
+                403: `Error respsone for 403`,
+                404: `Error respsone for 404`,
+                429: `Error respsone for 429`,
+            },
+        });
+    }
+    /**
+     * Get data from table by {id}.
+     * @param id Id
+     * @param lang The language if the default is not what you want.
+     * @param outputFormat
+     * @param requestBody A selection
+     * @returns string Success
+     * @throws ApiError
+     */
+    public static getTableDataByPost(
+        id: string,
+        lang?: string | null,
+        outputFormat?: string,
+        requestBody?: VariablesSelection,
+    ): CancelablePromise<string> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/tables/{id}/data',
+            path: {
+                'id': id,
+            },
+            query: {
+                'lang': lang,
+                'outputFormat': outputFormat,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Error respsone for 400`,
+                403: `Error respsone for 403`,
+                404: `Error respsone for 404`,
+                429: `Error respsone for 429`,
+            },
+        });
+    }
 }


### PR DESCRIPTION
This updates the API-query for the metadata to ask for the values used in the defaultSelection, and not the standard values.

Also added a try/catch to the mapper to output something when the mapper fails.