### PR TITLE
Dependabot version updates - Support NPM Workspaces and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/pxweb2"
+      - "/packages/pxweb2-api-client"
+      - "/packages/pxweb2-ui"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: auto
+    open-pull-requests-limit: 20
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    versioning-strategy: lockfile-only
-    open-pull-requests-limit: 20
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The `lockfile-only` was for NX compatibility i think