### PR TITLE
Remove Nx Console from recommended repo extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "nrwl.angular-console",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint"
   ]


### PR DESCRIPTION
Since we have removed Nx from the repository, we should not recommend the Nx Console extension for VSCode.