### PR TITLE
Remove unused eslint plugin for cypress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@typescript-eslint/parser": "8.19.0",
         "eslint": "8.57.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-cypress": "^2.15.2",
         "eslint-plugin-import": "2.31.0",
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-react": "7.32.2",
@@ -5010,19 +5009,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-cypress": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.15.2.tgz",
-      "integrity": "sha512-CtcFEQTDKyftpI22FVGpx8bkpKyYXBlNge6zSo0pl5/qJvBAnzaD76Vu2AsP16d6mTj478Ldn2mhgrWV+Xr0vQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globals": "^13.20.0"
-      },
-      "peerDependencies": {
-        "eslint": ">= 3.2.1"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@typescript-eslint/parser": "8.19.0",
     "eslint": "8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-cypress": "^2.15.2",
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react": "7.32.2",


### PR DESCRIPTION
This plugin was left when we removed Nx, and during that process removed cypress.