### PR TITLE
Fix/pxweb2-198: Show groupings last in codelists

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -8,15 +8,13 @@ import classes from './VariableBoxContent.module.scss';
 import { Checkbox, MixedCheckbox } from '../../Checkbox/Checkbox';
 import Search from '../../Search/Search';
 import { Select, SelectOption } from '../../Select/Select';
-import { VariableBoxProps } from '../VariableBox';
-import { SelectedVBValues } from '../VariableBox';
+import { VariableBoxProps, SelectedVBValues } from '../VariableBox';
 import { VartypeEnum } from '../../../shared-types/vartypeEnum';
 import { Value } from '../../../shared-types/value';
 import Skeleton from '../../Skeleton/Skeleton';
 import { mapCodeListsToSelectOptions } from '../../../util/util';
 import { BodyShort } from '../../Typography/BodyShort/BodyShort';
 import Heading from '../../Typography/Heading/Heading';
-import clsx from 'clsx';
 
 type VariableBoxPropsToContent = Omit<
   VariableBoxProps,
@@ -331,7 +329,7 @@ export function VariableBoxContent({
           <div
             id={varId}
             tabIndex={-1}
-            className={clsx(classes['focusableItem'], {
+            className={cl(classes['focusableItem'], {
               [classes['mixedCheckbox']]: true,
             })}
           >
@@ -360,7 +358,7 @@ export function VariableBoxContent({
           <div
             id={value.code}
             tabIndex={-1}
-            className={clsx(classes['focusableItem'])}
+            className={cl(classes['focusableItem'])}
           >
             <Checkbox
               id={value.code}

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -12,7 +12,7 @@ import { VariableBoxProps, SelectedVBValues } from '../VariableBox';
 import { VartypeEnum } from '../../../shared-types/vartypeEnum';
 import { Value } from '../../../shared-types/value';
 import Skeleton from '../../Skeleton/Skeleton';
-import { mapCodeListsToSelectOptions } from '../../../util/util';
+import { mapAndSortCodeLists } from '../utils';
 import { BodyShort } from '../../Typography/BodyShort/BodyShort';
 import Heading from '../../Typography/Heading/Heading';
 
@@ -94,6 +94,7 @@ export function VariableBoxContent({
         ?.values.sort() || []
     );
   }, [selectedValues, varId]);
+
   // The API always returns the oldest values first,
   // so we can just reverse the values array when the type is TIME_VARIABLE
   if (type === VartypeEnum.TIME_VARIABLE) {
@@ -191,17 +192,14 @@ export function VariableBoxContent({
     selectedValuesForVar,
   ]);
 
-  let mappedCodeLists: SelectOption[] = [];
-
-  if (hasCodeLists === true) {
-    mappedCodeLists = mapCodeListsToSelectOptions(codeLists);
-  }
+  const mappedAndSortedCodeLists: SelectOption[] =
+    mapAndSortCodeLists(codeLists);
 
   // needs the selected, mapped code list for the current variable
   const currentVarSelectedCodeListId = selectedValues.find(
     (variable) => variable.id === varId,
   )?.selectedCodeList;
-  const selectedCodeListMapped = mappedCodeLists.find(
+  const selectedCodeListMapped = mappedAndSortedCodeLists.find(
     (codeList) => codeList.value === currentVarSelectedCodeListId,
   );
   const selectedCodeListOrUndefined = selectedCodeListMapped ?? undefined;
@@ -475,7 +473,7 @@ export function VariableBoxContent({
               placeholder={t(
                 'presentation_page.sidemenu.selection.variablebox.content.select.placeholder',
               )}
-              options={mappedCodeLists}
+              options={mappedAndSortedCodeLists}
               selectedOption={selectedCodeListOrUndefined}
               onChange={(selectedItem) =>
                 handleChangingCodeListInVariableBox(

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/utils.spec.ts
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/utils.spec.ts
@@ -4,24 +4,44 @@ import { CodeList } from '../../shared-types/codelist';
 import { SelectOption } from '../Select/Select';
 import { sortSelectOptionsGroupingsLast, mapAndSortCodeLists } from './utils';
 
+const vsOptions: SelectOption[] = [
+  { label: 'VS Option 1', value: 'vs_1' },
+  { label: 'VS Option 2', value: 'vs_2' },
+  { label: 'VS Option 3', value: 'vs_3' },
+];
+const aggOptions: SelectOption[] = [
+  { label: 'Option 1', value: '1' },
+  { label: 'Option 2', value: '2' },
+];
+const mixedOptions: SelectOption[] = [
+  { label: 'VS Option 1', value: 'vs_1' },
+  { label: 'Option 1', value: '1' },
+  { label: 'VS Option 2', value: 'vs_2' },
+  { label: 'Option 2', value: '2' },
+  { label: 'VS Option 3', value: 'vs_3' },
+];
+const vsResults: SelectOption[] = [
+  { label: 'VS Option 1', value: 'vs_1' },
+  { label: 'VS Option 2', value: 'vs_2' },
+  { label: 'VS Option 3', value: 'vs_3' },
+];
+const aggResults: SelectOption[] = [
+  { label: 'Option 1', value: '1' },
+  { label: 'Option 2', value: '2' },
+];
+const mixedResults: SelectOption[] = [
+  { label: 'VS Option 1', value: 'vs_1' },
+  { label: 'VS Option 2', value: 'vs_2' },
+  { label: 'VS Option 3', value: 'vs_3' },
+  { label: 'Option 1', value: '1' },
+  { label: 'Option 2', value: '2' },
+];
+
 describe('sortSelectOptionsGroupingsFirst', () => {
   it('should sort options with "vs_" prefix to the top', () => {
-    const options: SelectOption[] = [
-      { label: 'VS Option 1', value: 'vs_1' },
-      { label: 'Option 1', value: '1' },
-      { label: 'VS Option 2', value: 'vs_2' },
-      { label: 'Option 2', value: '2' },
-      { label: 'VS Option 3', value: 'vs_3' },
-    ];
-    const result: SelectOption[] = sortSelectOptionsGroupingsLast(options);
+    const result: SelectOption[] = sortSelectOptionsGroupingsLast(mixedOptions);
 
-    expect(result).toEqual([
-      { label: 'VS Option 1', value: 'vs_1' },
-      { label: 'VS Option 2', value: 'vs_2' },
-      { label: 'VS Option 3', value: 'vs_3' },
-      { label: 'Option 1', value: '1' },
-      { label: 'Option 2', value: '2' },
-    ]);
+    expect(result).toEqual(mixedResults);
   });
 
   it('should return an empty array if options is empty', () => {
@@ -30,32 +50,16 @@ describe('sortSelectOptionsGroupingsFirst', () => {
     expect(result).toEqual([]);
   });
 
-  it('should work when there are no options vs_ prefix', () => {
-    const options: SelectOption[] = [
-      { label: 'AGG Option 1', value: 'agg_1' },
-      { label: 'AGG Option 2', value: 'agg_2' },
-    ];
-    const result: SelectOption[] = sortSelectOptionsGroupingsLast(options);
+  it('should work when there are only options with agg_ prefix', () => {
+    const result: SelectOption[] = sortSelectOptionsGroupingsLast(aggOptions);
 
-    expect(result).toEqual([
-      { label: 'AGG Option 1', value: 'agg_1' },
-      { label: 'AGG Option 2', value: 'agg_2' },
-    ]);
+    expect(result).toEqual(aggResults);
   });
 
-  it('should work when there are no options agg_ prefix', () => {
-    const options: SelectOption[] = [
-      { label: 'VS Option 1', value: 'vs_1' },
-      { label: 'VS Option 2', value: 'vs_2' },
-      { label: 'VS Option 3', value: 'vs_3' },
-    ];
-    const result: SelectOption[] = sortSelectOptionsGroupingsLast(options);
+  it('should work when there are only options with vs_ prefix', () => {
+    const result: SelectOption[] = sortSelectOptionsGroupingsLast(vsOptions);
 
-    expect(result).toEqual([
-      { label: 'VS Option 1', value: 'vs_1' },
-      { label: 'VS Option 2', value: 'vs_2' },
-      { label: 'VS Option 3', value: 'vs_3' },
-    ]);
+    expect(result).toEqual(vsResults);
   });
 });
 

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/utils.spec.ts
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/utils.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+
+import { CodeList } from '../../shared-types/codelist';
+import { SelectOption } from '../Select/Select';
+import { sortSelectOptionsGroupingsLast, mapAndSortCodeLists } from './utils';
+
+describe('sortSelectOptionsGroupingsFirst', () => {
+  it('should sort options with "vs_" prefix to the top', () => {
+    const options: SelectOption[] = [
+      { label: 'VS Option 1', value: 'vs_1' },
+      { label: 'Option 1', value: '1' },
+      { label: 'VS Option 2', value: 'vs_2' },
+      { label: 'Option 2', value: '2' },
+      { label: 'VS Option 3', value: 'vs_3' },
+    ];
+    const result: SelectOption[] = sortSelectOptionsGroupingsLast(options);
+
+    expect(result).toEqual([
+      { label: 'VS Option 1', value: 'vs_1' },
+      { label: 'VS Option 2', value: 'vs_2' },
+      { label: 'VS Option 3', value: 'vs_3' },
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+    ]);
+  });
+
+  it('should return an empty array if options is empty', () => {
+    const result: SelectOption[] = sortSelectOptionsGroupingsLast([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should work when there are no options vs_ prefix', () => {
+    const options: SelectOption[] = [
+      { label: 'AGG Option 1', value: 'agg_1' },
+      { label: 'AGG Option 2', value: 'agg_2' },
+    ];
+    const result: SelectOption[] = sortSelectOptionsGroupingsLast(options);
+
+    expect(result).toEqual([
+      { label: 'AGG Option 1', value: 'agg_1' },
+      { label: 'AGG Option 2', value: 'agg_2' },
+    ]);
+  });
+
+  it('should work when there are no options agg_ prefix', () => {
+    const options: SelectOption[] = [
+      { label: 'VS Option 1', value: 'vs_1' },
+      { label: 'VS Option 2', value: 'vs_2' },
+      { label: 'VS Option 3', value: 'vs_3' },
+    ];
+    const result: SelectOption[] = sortSelectOptionsGroupingsLast(options);
+
+    expect(result).toEqual([
+      { label: 'VS Option 1', value: 'vs_1' },
+      { label: 'VS Option 2', value: 'vs_2' },
+      { label: 'VS Option 3', value: 'vs_3' },
+    ]);
+  });
+});
+
+describe('mapAndSortCodeLists', () => {
+  it('should return an empty array if codeLists is undefined', () => {
+    const result = mapAndSortCodeLists(undefined);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array if codeLists is empty', () => {
+    const result = mapAndSortCodeLists([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should map codeLists to select options without sorting if no sorting is needed', () => {
+    const codeLists: CodeList[] = [
+      { id: 'test_1', label: 'Test 1' },
+      { id: 'test_2', label: 'Test 2' },
+    ];
+    const expected: SelectOption[] = [
+      { value: 'test_1', label: 'Test 1' },
+      { value: 'test_2', label: 'Test 2' },
+    ];
+    const result = mapAndSortCodeLists(codeLists);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should map and sort codeLists if sorting is needed', () => {
+    const codeLists: CodeList[] = [
+      { id: 'agg_test', label: 'AGG Test' },
+      { id: 'vs_test', label: 'VS Test' },
+    ];
+    const expected: SelectOption[] = [
+      { value: 'vs_test', label: 'VS Test' },
+      { value: 'agg_test', label: 'AGG Test' },
+    ];
+    const result = mapAndSortCodeLists(codeLists);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/utils.ts
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/utils.ts
@@ -1,0 +1,38 @@
+import { SelectOption } from '../Select/Select';
+import { CodeList } from '../../shared-types/codelist';
+import { mapCodeListsToSelectOptions } from '../../util/util';
+
+export const sortSelectOptionsGroupingsLast = (
+  options: SelectOption[],
+): SelectOption[] => {
+  if (options.length < 1) {
+    return [];
+  }
+
+  // if value starts with "vs_", put them at the top
+  const vsOptions = options.filter((option) => option.value.startsWith('vs_'));
+  const otherOptions = options.filter(
+    (option) => !option.value.startsWith('vs_'),
+  );
+
+  return [...vsOptions, ...otherOptions];
+};
+
+export const mapAndSortCodeLists = (
+  codeLists: CodeList[] | undefined,
+): SelectOption[] => {
+  if (!codeLists || codeLists.length === 0) {
+    return [];
+  }
+
+  const needsSorting =
+    codeLists.some((codeList) => codeList.id.toLowerCase().startsWith('vs_')) &&
+    codeLists.some((codeList) => codeList.id.toLowerCase().startsWith('agg_'));
+  const mappedCodeLists = mapCodeListsToSelectOptions(codeLists);
+
+  if (needsSorting) {
+    return sortSelectOptionsGroupingsLast(mappedCodeLists);
+  }
+
+  return mappedCodeLists;
+};

--- a/packages/pxweb2-ui/src/lib/util/util.spec.ts
+++ b/packages/pxweb2-ui/src/lib/util/util.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  getCSSVariable,
+  mapCodeListToSelectOption,
+  mapCodeListsToSelectOptions,
+} from './util';
+import { CodeList } from '../shared-types/codelist';
+import { SelectOption } from '../components/Select/Select';
+
+describe('getCSSVariable', () => {
+  beforeEach(() => {
+    const style = document.createElement('style');
+    style.innerHTML = ':root { --test-variable: #123456; }';
+
+    document.head.appendChild(style);
+  });
+
+  it('should return the value of a CSS variable', () => {
+    const result = getCSSVariable('--test-variable');
+
+    expect(result).toBe('#123456');
+  });
+});
+
+describe('mapCodeListToSelectOption', () => {
+  it('should map a CodeList to a SelectOption', () => {
+    const codeList: CodeList = { id: '1', label: 'Option 1' };
+    const result: SelectOption = mapCodeListToSelectOption(codeList);
+
+    expect(result).toEqual({ label: 'Option 1', value: '1' });
+  });
+});
+
+describe('mapCodeListsToSelectOptions', () => {
+  it('should map an array of CodeLists to an array of SelectOptions', () => {
+    const codeLists: CodeList[] = [
+      { id: '1', label: 'Option 1' },
+      { id: '2', label: 'Option 2' },
+    ];
+    const result: SelectOption[] = mapCodeListsToSelectOptions(codeLists);
+
+    expect(result).toEqual([
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+    ]);
+  });
+});

--- a/packages/pxweb2-ui/src/lib/util/util.ts
+++ b/packages/pxweb2-ui/src/lib/util/util.ts
@@ -7,12 +7,12 @@ export const getCSSVariable = (variable: string): string => {
   return cssVar;
 };
 
-export const mapCodeListToSelectOption = (
-  codeList: CodeList,
-): SelectOption => ({
-  label: codeList.label,
-  value: codeList.id,
-});
+export const mapCodeListToSelectOption = (codeList: CodeList): SelectOption => {
+  return {
+    label: codeList.label,
+    value: codeList.id,
+  };
+};
 
 // return array of SelectOption objects
 export const mapCodeListsToSelectOptions = (


### PR DESCRIPTION
This moves the groupings last when there are both groupings and value
aggs among the codelists. Also added some tests, and minor refactor.