### PR TITLE
Fix checks for contexts being inside Providers

### DIFF
--- a/packages/pxweb2/src/app/app.spec.tsx
+++ b/packages/pxweb2/src/app/app.spec.tsx
@@ -1,7 +1,16 @@
-import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 
 import App from './app';
-import { MemoryRouter } from 'react-router';
+import { renderWithProviders } from './util/testing-utils';
+import { Config } from './util/config/configType';
+
+// Declare the global variable for this file
+declare global {
+  interface Window {
+    PxWeb2Config: Config;
+  }
+}
+
 window.PxWeb2Config = {
   language: {
     supportedLanguages: [
@@ -13,15 +22,17 @@ window.PxWeb2Config = {
     defaultLanguage: 'en',
     fallbackLanguage: 'en',
   },
+  apiUrl: '',
 };
 
 describe('App', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(
+    const { baseElement } = renderWithProviders(
       <MemoryRouter>
         <App />
       </MemoryRouter>,
     );
+
     expect(baseElement).toBeTruthy();
   });
 });

--- a/packages/pxweb2/src/app/components/Presentation/Presentation.spec.tsx
+++ b/packages/pxweb2/src/app/components/Presentation/Presentation.spec.tsx
@@ -1,10 +1,12 @@
-import { render } from '@testing-library/react';
-
+import { renderWithProviders } from '../../util/testing-utils';
 import Presentation from './Presentation';
 
 describe('Presentation', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<Presentation />);
+    const { baseElement } = renderWithProviders(
+      <Presentation selectedTabId="1" />,
+    );
+
     expect(baseElement).toBeTruthy();
   });
 });

--- a/packages/pxweb2/src/app/components/Selection/Selection.spec.tsx
+++ b/packages/pxweb2/src/app/components/Selection/Selection.spec.tsx
@@ -1,10 +1,16 @@
-import { render } from '@testing-library/react';
-
+import { renderWithProviders } from '../../util/testing-utils';
 import Selection from './Selection';
 
 describe('Selection', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<Selection />);
+    const { baseElement } = renderWithProviders(
+      <Selection
+        selectedNavigationView=""
+        selectedTabId="1"
+        setSelectedNavigationView={() => {}}
+      />,
+    );
+
     expect(baseElement).toBeTruthy();
   });
 });

--- a/packages/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/packages/pxweb2/src/app/context/TableDataProvider.tsx
@@ -1,5 +1,12 @@
 import { i18n } from 'i18next';
-import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import React, {
+  createContext,
+  useEffect,
+  useMemo,
+  useState,
+  ReactNode,
+} from 'react';
+
 import useVariables from './useVariables';
 import {
   Dataset,
@@ -17,6 +24,7 @@ import { mapJsonStat2Response } from '../../mappers/JsonStat2ResponseMapper';
 
 // Define types for the context state and provider props
 export interface TableDataContextType {
+  isInitialized: boolean;
   data: PxTable | undefined;
   /*   loading: boolean;
   error: string | null; */
@@ -29,12 +37,14 @@ interface TableDataProviderProps {
 
 // Create context with default values
 const TableDataContext = createContext<TableDataContextType | undefined>({
+  isInitialized: false,
   data: undefined,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   fetchTableData: () => {},
 });
 
 const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
+  const [isInitialized] = useState(true);
   // Data (metadata) that reflects variables and values selected by user right now. Used as data source for the table
   const [data, setData] = useState<PxTable | undefined>(undefined);
   // Accumulated data (and metadata) from all API calls made by user. Stored in the data cube.
@@ -63,38 +73,42 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
    * @param i18n - The i18n object for handling langauages
    */
   const fetchTableData = async (tableId: string, i18n: i18n) => {
-    const selections: Array<VariableSelection> = [];
+    try {
+      const selections: Array<VariableSelection> = [];
 
-    // Get selection from Selection provider
-    const ids = variables.getUniqueIds();
-    ids.forEach((id) => {
-      const selectedCodeList = variables.getSelectedCodelistById(id);
-      const selection: VariableSelection = {
-        variableCode: id,
-        valueCodes: variables.getSelectedValuesByIdSorted(id),
-      };
+      // Get selection from Selection provider
+      const ids = variables.getUniqueIds();
+      ids.forEach((id) => {
+        const selectedCodeList = variables.getSelectedCodelistById(id);
+        const selection: VariableSelection = {
+          variableCode: id,
+          valueCodes: variables.getSelectedValuesByIdSorted(id),
+        };
 
-      // Add selected codelist to selection if it exists
-      if (selectedCodeList) {
-        selection.codeList = selectedCodeList;
+        // Add selected codelist to selection if it exists
+        if (selectedCodeList) {
+          selection.codeList = selectedCodeList;
+        }
+
+        selections.push(selection);
+      });
+
+      const variablesSelection: VariablesSelection = { selection: selections };
+
+      // Check if we have accumulated data in the data cube and if it is valid. If not we cannot use it.
+      const validAccData: boolean = isAccumulatedDataValid(
+        variablesSelection,
+        i18n.language,
+        tableId,
+      );
+
+      if (validAccData) {
+        await fetchWithValidAccData(tableId, i18n, variablesSelection);
+      } else {
+        await fetchWithoutValidAccData(tableId, i18n, variablesSelection);
       }
-
-      selections.push(selection);
-    });
-
-    const variablesSelection: VariablesSelection = { selection: selections };
-
-    // Check if we have accumulated data in the data cube and if it is valid. If not we cannot use it.
-    const validAccData: boolean = isAccumulatedDataValid(
-      variablesSelection,
-      i18n.language,
-      tableId,
-    );
-
-    if (validAccData) {
-      fetchWithValidAccData(tableId, i18n, variablesSelection);
-    } else {
-      fetchWithoutValidAccData(tableId, i18n, variablesSelection);
+    } catch (error) {
+      setErrorMsg('Failed to fetch table data. Please try again later.');
     }
   };
 
@@ -676,10 +690,25 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
     }
   }
 
+  const memoizedValues = useMemo(
+    () => ({
+      isInitialized,
+      data,
+      // loading,
+      // error,
+      fetchTableData,
+    }),
+    [
+      isInitialized,
+      data,
+      // loading,
+      // error,
+      fetchTableData,
+    ],
+  );
+
   return (
-    <TableDataContext.Provider
-      value={{ data, /* loading, error  */ fetchTableData }}
-    >
+    <TableDataContext.Provider value={memoizedValues}>
       {children}
     </TableDataContext.Provider>
   );

--- a/packages/pxweb2/src/app/context/VariablesProvider.tsx
+++ b/packages/pxweb2/src/app/context/VariablesProvider.tsx
@@ -1,10 +1,10 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useMemo, useState } from 'react';
 
-import { SelectedVBValues } from '@pxweb2/pxweb2-ui';
-import { PxTableMetadata } from '@pxweb2/pxweb2-ui';
+import { SelectedVBValues, PxTableMetadata } from '@pxweb2/pxweb2-ui';
 
 // Define the type for the context
 export type VariablesContextType = {
+  isInitialized: boolean;
   addSelectedValues: (variableId: string, values: string[]) => void;
   getSelectedValuesById: (variableId: string) => string[];
   getSelectedValuesByIdSorted: (variableId: string) => string[];
@@ -27,6 +27,7 @@ export type VariablesContextType = {
 
 // Create the context with default values
 export const VariablesContext = createContext<VariablesContextType>({
+  isInitialized: false,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   addSelectedValues: () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -56,6 +57,7 @@ export const VariablesContext = createContext<VariablesContextType>({
 export const VariablesProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
+  const [isInitialized] = useState(true);
   const [variables, setVariables] = useState<
     Map<string, { id: string; value: string }>
   >(new Map());
@@ -64,11 +66,9 @@ export const VariablesProvider: React.FC<{ children: React.ReactNode }> = ({
   const [pxTableMetadata, setPxTableMetadata] =
     useState<PxTableMetadata | null>(null);
 
-  // const [prevTableId, setPrevTableId] = useState('');
   const [isLoadingMetadata, setIsLoadingMetadata] = useState<boolean>(false);
   const [hasLoadedDefaultSelection, setHasLoadedDefaultSelection] =
     useState(false);
-  // const { i18n, t } = useTranslation();
   const [selectedVBValues, setSelectedVBValues] = useState<SelectedVBValues[]>(
     [],
   );
@@ -196,27 +196,49 @@ export const VariablesProvider: React.FC<{ children: React.ReactNode }> = ({
     return str;
   };
 
+  const memoizedValues = useMemo(
+    () => ({
+      isInitialized,
+      addSelectedValues,
+      getNumberOfSelectedValues,
+      getSelectedValuesById,
+      getSelectedValuesByIdSorted,
+      getSelectedCodelistById,
+      getUniqueIds,
+      syncVariablesAndValues,
+      toString,
+      hasLoadedDefaultSelection,
+      setHasLoadedDefaultSelection,
+      setSelectedVBValues,
+      selectedVBValues,
+      isLoadingMetadata,
+      setIsLoadingMetadata,
+      pxTableMetadata,
+      setPxTableMetadata,
+    }),
+    [
+      isInitialized,
+      addSelectedValues,
+      getNumberOfSelectedValues,
+      getSelectedValuesById,
+      getSelectedValuesByIdSorted,
+      getSelectedCodelistById,
+      getUniqueIds,
+      syncVariablesAndValues,
+      toString,
+      hasLoadedDefaultSelection,
+      setHasLoadedDefaultSelection,
+      setSelectedVBValues,
+      selectedVBValues,
+      isLoadingMetadata,
+      setIsLoadingMetadata,
+      pxTableMetadata,
+      setPxTableMetadata,
+    ],
+  );
+
   return (
-    <VariablesContext.Provider
-      value={{
-        addSelectedValues,
-        getNumberOfSelectedValues,
-        getSelectedValuesById,
-        getSelectedValuesByIdSorted,
-        getSelectedCodelistById,
-        getUniqueIds,
-        syncVariablesAndValues,
-        toString,
-        hasLoadedDefaultSelection,
-        selectedVBValues,
-        setSelectedVBValues,
-        isLoadingMetadata,
-        pxTableMetadata,
-        setHasLoadedDefaultSelection,
-        setIsLoadingMetadata,
-        setPxTableMetadata,
-      }}
-    >
+    <VariablesContext.Provider value={memoizedValues}>
       {children}
     </VariablesContext.Provider>
   );

--- a/packages/pxweb2/src/app/context/useTableData.ts
+++ b/packages/pxweb2/src/app/context/useTableData.ts
@@ -3,7 +3,7 @@ import { TableDataContext, TableDataContextType } from './TableDataProvider';
 
 const useTableData = (): TableDataContextType => {
   const context = useContext(TableDataContext);
-  if (context === undefined) {
+  if (!context || context?.isInitialized === false) {
     throw new Error('useTableData must be used within a TableProvider');
   }
   return context;

--- a/packages/pxweb2/src/app/context/useVariables.ts
+++ b/packages/pxweb2/src/app/context/useVariables.ts
@@ -3,7 +3,7 @@ import { VariablesContext, VariablesContextType } from './VariablesProvider';
 
 const useVariables = (): VariablesContextType => {
   const context = useContext(VariablesContext);
-  if (context === undefined) {
+  if (context.isInitialized === false) {
     throw new Error('useVariables must be used within a VariableProvider');
   }
   return context;

--- a/packages/pxweb2/src/app/util/testing-utils.tsx
+++ b/packages/pxweb2/src/app/util/testing-utils.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { VariablesProvider } from '../context/VariablesProvider';
+import { TableDataProvider } from '../context/TableDataProvider';
+
+const renderWithProviders = (ui: React.ReactNode) => {
+  return render(
+    <VariablesProvider>
+      <TableDataProvider>{ui}</TableDataProvider>
+    </VariablesProvider>,
+  );
+};
+
+export { renderWithProviders };


### PR DESCRIPTION
The checks for TableDataProvider and VariablesProvider did not work, since both have default variables. This expands them to have an 'initialized' variable that defaults to false, and then is set to true when creating the context.

Also had to fix some tests, since they now correctly were failing. And also some had to fix some unhandled errors in fetchTableData.