### PR TITLE
fix/Add storybook-static to lint ignore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ export default [
       '**/.next/**',
       '**/build/**',
       '**/packages/pxweb2-api-client/**',
+      '**/storybook-static/**',
       '**/.cache/**',
     ],
   },


### PR DESCRIPTION
This fixes an issue where sometimes the output directory for storybook isn't moved. Which meant the lint rules that run before commits would lint inside the generated storybook folder. This was a problem since there were many issues to our lint rules in there. It was allready ignored by git, so I see no reason to not just ignore it for linting too.