### PR TITLE
Fix the error in vite.config in pxweb2ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@pxweb2/source",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "prepare": "husky",
     "lint": "eslint --fix",


### PR DESCRIPTION
This fixes the error with the '__dirname' in the vite config of pxweb2ui. The type field was missing in all the package.json files, which means they default to the old CommonJS modules. I see no reason we should not default to the modern modules in any project in this repo, so setting it in the root package.json.