### PR TITLE
Fix missing type-module in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@pxweb2/source",
   "version": "0.0.0",
   "license": "MIT",
-  "type": "module",
   "scripts": {
     "prepare": "husky",
     "lint": "eslint --fix",

--- a/packages/pxweb2-api-client/package.json
+++ b/packages/pxweb2-api-client/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "main": "./src/index.ts",
   "private": "true",
+  "type": "module",
   "devDependencies": {},
   "scripts": {
     "build": "vite build",

--- a/packages/pxweb2-ui/package.json
+++ b/packages/pxweb2-ui/package.json
@@ -2,6 +2,7 @@
   "name": "@pxweb2/pxweb2-ui",
   "version": "0.0.1",
   "main": "./src/index.ts",
+  "type": "module",
   "scripts": {
     "start": "npm run storybook",
     "build": "npm run build-style-dictionary && storybook build && mv ./storybook-static ../pxweb2/dist/storybook",

--- a/packages/pxweb2/package.json
+++ b/packages/pxweb2/package.json
@@ -6,6 +6,7 @@
   "author": "",
   "license": "MIT",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "vite build",

--- a/packages/pxweb2/vite.config.ts
+++ b/packages/pxweb2/vite.config.ts
@@ -8,10 +8,16 @@ const themeInjectorPlugin = (): Plugin => ({
   name: 'theme-injector',
   transformIndexHtml(html) {
     // Remove the theme CSS link from the original HTML
-    html = html.replace('<link rel="stylesheet" href="/theme/variables.css" />', '');
-    
+    html = html.replace(
+      '<link rel="stylesheet" href="/theme/variables.css" />',
+      '',
+    );
+
     // Inject it at the end of head to ensure it loads last
-    return html.replace('</head>', '<link rel="stylesheet" href="/theme/variables.css" /></head>');
+    return html.replace(
+      '</head>',
+      '<link rel="stylesheet" href="/theme/variables.css" /></head>',
+    );
   },
 });
 
@@ -30,18 +36,11 @@ export default defineConfig({
       },
     },
   },
-
   preview: {
     port: 4300,
     host: 'localhost',
   },
-
-  plugins: [
-    react(),
-    themeInjectorPlugin(),
-  ],
-
-
+  plugins: [react(), themeInjectorPlugin()],
   build: {
     outDir: './dist/',
     reportCompressedSize: true,
@@ -49,13 +48,11 @@ export default defineConfig({
       transformMixedEsModules: true,
     },
   },
-
   resolve: {
     alias: {
       $ui: path.resolve('../pxweb2-ui/'),
     },
   },
-
   test: {
     globals: true,
     cache: {


### PR DESCRIPTION
This adds the line '"type": "module"' to the package.json files that are missing it as of now. It cleans up the messages we get when we build the projects. There were several places where it complained that we built it using the old "require()" way. This made reading the terminal output more difficult than it needs to be.

It also adds some formatting to one vite.config.ts file, but nothing functional in it has changed.

Not sure if we need the '"type": "module"' line in the root project, so leaving it for now.