### PR TITLE
Remove the last types from NX in the projecct

### DIFF
--- a/packages/pxweb2-ui/tsconfig.lib.json
+++ b/packages/pxweb2-ui/tsconfig.lib.json
@@ -4,8 +4,6 @@
     "outDir": "./dist/out-tsc",
     "types": [
       "node",
-      "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts",
       "vite/client"
     ]
   },

--- a/packages/pxweb2-ui/tsconfig.storybook.json
+++ b/packages/pxweb2-ui/tsconfig.storybook.json
@@ -5,9 +5,7 @@
     "outDir": ""
   },
   "files": [
-    "../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../node_modules/@nx/react/typings/image.d.ts"
+    "vite.config.ts",
   ],
   "exclude": [
     "src/**/*.spec.ts",

--- a/packages/pxweb2/tsconfig.app.json
+++ b/packages/pxweb2/tsconfig.app.json
@@ -4,8 +4,6 @@
     "outDir": "../../dist/out-tsc",
     "types": [
       "node",
-      "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts",
       "vite/client"
     ]
   },

--- a/packages/pxweb2/tsconfig.spec.json
+++ b/packages/pxweb2/tsconfig.spec.json
@@ -8,8 +8,6 @@
       "vite/client",
       "node",
       "vitest",
-      "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
     ]
   },
   "include": [


### PR DESCRIPTION
This fixes the errors we have in the tsconfig files from the old types from NX that were left. After this there should not be many more times where we have the red 'error' indicator in our IDEs from config files. One exception is the one file with a test part, that causes an error.