### PR TITLE
Add mocking in test for useTranslate

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,16 @@
+# Path to sources
+#sonar.sources=.
+sonar.exclusions="**/**.spec.**"
+#sonar.inclusions=
+ 
+# Path to tests
+#sonar.tests=
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+ 
+# Source encoding
+#sonar.sourceEncoding=UTF-8
+ 
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=
+ 

--- a/packages/pxweb2-ui/src/index.ts
+++ b/packages/pxweb2-ui/src/index.ts
@@ -29,5 +29,6 @@ export * from './lib/shared-types/value';
 export * from './lib/shared-types/variable';
 export * from './lib/shared-types/vartypeEnum';
 export * from './lib/util/util';
+export * from './lib/util/testing-utils';
 export * from './../style-dictionary/dist/js/css-variables';
 export * from './../style-dictionary/dist/js/fixed-variables';

--- a/packages/pxweb2-ui/src/lib/components/Alert/Alert.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Alert/Alert.spec.tsx
@@ -1,10 +1,15 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '../../../lib/util/testing-utils';
+mockReactI18next();
+
 import { render } from '@testing-library/react';
 
 import Alert from './Alert';
 
 describe('Alert', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<Alert />);
+    const { baseElement } = render(<Alert variant="info" />);
     expect(baseElement).toBeTruthy();
   });
 });

--- a/packages/pxweb2-ui/src/lib/components/Modal/Modal.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Modal/Modal.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '../../../lib/util/testing-utils';
+mockReactI18next();
+
 import { render } from '@testing-library/react';
 import Modal from './Modal';
 

--- a/packages/pxweb2-ui/src/lib/components/Spinner/Spinner.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Spinner/Spinner.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '../../../lib/util/testing-utils';
+mockReactI18next();
+
 import { render } from '@testing-library/react';
 
 import Spinner from './Spinner';

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBox.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBox.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '../../../lib/util/testing-utils';
+mockReactI18next();
+
 import { render } from '@testing-library/react';
 
 import VariableBox from './VariableBox';
@@ -24,6 +29,12 @@ describe('VariableBox', () => {
         }}
         selectedValues={[]}
         type={VartypeEnum.CONTENTS_VARIABLE}
+        addModal={() => {
+          return;
+        }}
+        removeModal={() => {
+          return;
+        }}
       />,
     );
 

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '../../../../lib/util/testing-utils';
+mockReactI18next();
+
 import { render } from '@testing-library/react';
 
 import VariableBoxContent from './VariableBoxContent';
@@ -17,6 +22,12 @@ describe('VariableBoxContent', () => {
           return;
         }}
         onChangeMixedCheckbox={() => {
+          return;
+        }}
+        addModal={() => {
+          return;
+        }}
+        removeModal={() => {
           return;
         }}
         varId="test-1"

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '../../../../lib/util/testing-utils';
+mockReactI18next();
+
 import { render } from '@testing-library/react';
 
 import VariableBoxHeader from './VariableBoxHeader';

--- a/packages/pxweb2-ui/src/lib/components/VariableList/VariableList.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableList/VariableList.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '../../../lib/util/testing-utils';
+mockReactI18next();
+
 import { render } from '@testing-library/react';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import { VariableList } from './VariableList';
@@ -86,6 +91,13 @@ describe('VariableList', () => {
         handleMixedCheckboxChange={() => {
           return;
         }}
+        isChangingCodeList={false}
+        addModal={() => {
+          return;
+        }}
+        removeModal={() => {
+          return;
+        }}
       />,
     );
 
@@ -106,6 +118,13 @@ describe('VariableList', () => {
           return;
         }}
         handleMixedCheckboxChange={() => {
+          return;
+        }}
+        isChangingCodeList={false}
+        addModal={() => {
+          return;
+        }}
+        removeModal={() => {
           return;
         }}
       />,
@@ -140,6 +159,13 @@ describe('VariableList', () => {
         handleMixedCheckboxChange={() => {
           return;
         }}
+        isChangingCodeList={false}
+        addModal={() => {
+          return;
+        }}
+        removeModal={() => {
+          return;
+        }}
       />,
       {
         wrapper: ({ children }) => (
@@ -170,6 +196,13 @@ describe('VariableList', () => {
           return;
         }}
         handleMixedCheckboxChange={() => {
+          return;
+        }}
+        isChangingCodeList={true}
+        addModal={() => {
+          return;
+        }}
+        removeModal={() => {
           return;
         }}
       />,

--- a/packages/pxweb2-ui/src/lib/util/testing-utils.ts
+++ b/packages/pxweb2-ui/src/lib/util/testing-utils.ts
@@ -1,18 +1,20 @@
 import { vi } from 'vitest';
 
-export const mockReactI18next = () => {
-  vi.mock('react-i18next', () => ({
-    useTranslation: () => ({
-      t: (key: string) => key,
-      i18n: {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        changeLanguage: () => new Promise(() => {}),
-      },
-    }),
-    initReactI18next: {
-      type: '3rdParty',
+const mockConfig = {
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      init: () => {},
+      changeLanguage: () => new Promise(() => {}),
     },
-  }));
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    init: () => {},
+  },
+};
+
+export const mockReactI18next = () => {
+  vi.mock('react-i18next', () => mockConfig);
 };

--- a/packages/pxweb2-ui/src/lib/util/testing-utils.ts
+++ b/packages/pxweb2-ui/src/lib/util/testing-utils.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest';
+
+export const mockReactI18next = () => {
+  vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        changeLanguage: () => new Promise(() => {}),
+      },
+    }),
+    initReactI18next: {
+      type: '3rdParty',
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      init: () => {},
+    },
+  }));
+};

--- a/packages/pxweb2/src/app/app.spec.tsx
+++ b/packages/pxweb2/src/app/app.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '@pxweb2/pxweb2-ui';
+mockReactI18next();
+
 import { MemoryRouter } from 'react-router';
 import App from './app';
 import { AccessibilityProvider } from './context/AccessibilityProvider';

--- a/packages/pxweb2/src/app/components/ContentTop/ContentTop.spec.tsx
+++ b/packages/pxweb2/src/app/components/ContentTop/ContentTop.spec.tsx
@@ -1,13 +1,18 @@
-import { render } from '@testing-library/react';
-
-import ContentTop from './ContentTop';
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
 import {
   Variable,
   VartypeEnum,
   PxTableMetadata,
   PxTable,
   fakeData,
+  mockReactI18next,
 } from '@pxweb2/pxweb2-ui';
+mockReactI18next();
+
+import { render } from '@testing-library/react';
+
+import ContentTop from './ContentTop';
 
 function getPxTable(): PxTable {
   const variables: Variable[] = [
@@ -61,6 +66,7 @@ function getPxTable(): PxTable {
   const tableMeta: PxTableMetadata = {
     id: 'test01',
     label: 'Test table',
+    language: 'no',
     updated: new Date('2023-01-14T09:00:05.123Z'),
     variables: variables,
   };

--- a/packages/pxweb2/src/app/components/NavigationMenu/NavigationBar/NavigationBar.spec.tsx
+++ b/packages/pxweb2/src/app/components/NavigationMenu/NavigationBar/NavigationBar.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '@pxweb2/pxweb2-ui';
+mockReactI18next();
+
 import { getByText, render } from '@testing-library/react';
 
 import NavigationBar from './NavigationBar';

--- a/packages/pxweb2/src/app/components/NavigationMenu/NavigationRail/NavigationRail.spec.tsx
+++ b/packages/pxweb2/src/app/components/NavigationMenu/NavigationRail/NavigationRail.spec.tsx
@@ -1,3 +1,8 @@
+// Mock react-i18next's useTranslation hook
+// needs to be imported before the component
+import { mockReactI18next } from '@pxweb2/pxweb2-ui';
+mockReactI18next();
+
 import { getByText, render } from '@testing-library/react';
 
 import NavigationRail from './NavigationRail';


### PR DESCRIPTION
This fixes the spam we have had in the terminal related to react-i18next and the useTranslate function. It has been quite spammy, making the testing results hard to read.

Took some troubleshooting to get it to work, but made a mocking function in the ui library, and the export it to the web app to use it there too. The lines for importing and using them are at the top of the files, because they need to be ran before importing the other components that use the function. This seems clearer and easier to deal with than trying to figure out which import line needs to be moved below the others.

Also fixed some small issues with missing variables in the tests where I saw them.