### PR TITLE
Fix mocking of react-i18next's useTranslate

### DIFF
--- a/packages/pxweb2-ui/src/lib/util/setupTests.ts
+++ b/packages/pxweb2-ui/src/lib/util/setupTests.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      changeLanguage: () => new Promise(() => {}),
+    },
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    init: () => {},
+  },
+}));

--- a/packages/pxweb2-ui/vitest.config.ts
+++ b/packages/pxweb2-ui/vitest.config.ts
@@ -11,6 +11,7 @@ export default mergeConfig(
       },
       environment: 'jsdom',
       include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      setupFiles: './src/lib/util/setupTests',
 
       reporters: ['default'],
       coverage: {

--- a/packages/pxweb2/test/setupTests.ts
+++ b/packages/pxweb2/test/setupTests.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      changeLanguage: () => new Promise(() => {}),
+    },
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    init: () => {},
+  },
+}));

--- a/packages/pxweb2/vitest.config.ts
+++ b/packages/pxweb2/vitest.config.ts
@@ -11,6 +11,7 @@ export default mergeConfig(
       },
       environment: 'jsdom',
       include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      setupFiles: './test/setupTests',
 
       reporters: ['default'],
       coverage: {


### PR DESCRIPTION
This is the second attempt at mocking the useTranslate function from react-i18next. The first time broke the dev environment, but lead to other fixes and to the beginning of this fix. Adds a setupTests file to both the web application and the ui-library. Tested it, and it seems to work fine now. Dev environment runs fine, and the terminal is not spammed with react-i18next errors when running tests.

Please do test this, since we (I) do not want to break something in main again :D