### PR TITLE
Last focus fix

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.module.scss
@@ -13,10 +13,6 @@
     background-color: var(--px-color-surface-action-subtle-active);
   }
 
-  &:focus {
-    background-color: var(--px-color-surface-action-subtle-active);
-  }
-
   &:focus-visible .checkmark {
     outline: 3px solid var(--px-color-border-focus-outline);
 

--- a/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
@@ -25,8 +25,11 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   strong,
   noMargin,
 }) => {
+  const checkboxRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <div
+      ref={checkboxRef}
       id={id}
       role="checkbox"
       aria-checked={value}

--- a/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
@@ -25,11 +25,8 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   strong,
   noMargin,
 }) => {
-  const checkboxRef = React.useRef<HTMLDivElement>(null);
-
   return (
     <div
-      ref={checkboxRef}
       id={id}
       role="checkbox"
       aria-checked={value}

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.module.scss
@@ -117,7 +117,6 @@
 }
 
 .focusableItem:focus-within {
-  background-color: #c3dcdc;
   margin-left: 4px;
   margin-right: 4px;
   border-radius: 4px;

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -379,6 +379,7 @@ export function VariableBoxContent({
           <div
             id={varId}
             tabIndex={-1}
+            onFocus={(event) => event.target.childNodes[0].focus()}
             className={cl(classes['focusableItem'], {
               [classes['mixedCheckbox']]: true,
             })}
@@ -408,6 +409,7 @@ export function VariableBoxContent({
           <div
             id={value.code}
             tabIndex={-1}
+            onFocus={(event) => event.target.childNodes[0].focus()}
             className={cl(classes['focusableItem'])}
           >
             <Checkbox

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -371,7 +371,7 @@ export function VariableBoxContent({
             id={varId + uniqueId}
             tabIndex={-1}
             onFocus={(event) => {
-              event.target.childNodes[0].focus();
+              (event.target.childNodes[0] as HTMLElement).focus();
               if (hasSevenOrMoreValues) {
                 setCurrentFocusedItemIndex(1);
               } else {
@@ -408,7 +408,7 @@ export function VariableBoxContent({
             id={value.code + uniqueId}
             tabIndex={-1}
             onFocus={(event) => {
-              event.target.childNodes[0].focus();
+              (event.target.childNodes[0] as HTMLElement).focus();
             }}
             className={cl(classes['focusableItem'])}
           >

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -86,7 +86,7 @@ export function VariableBoxContent({
     number | null
   >(null);
   const [items, setItems] = useState<{ type: string; value?: Value }[]>([]);
-
+  const [uniqueId] = useState(Math.random());
   const valuesOnlyList = useRef<HTMLDivElement>(null);
   const hasCodeLists = codeLists && codeLists.length > 0;
   const hasSevenOrMoreValues = values && values.length > 6;
@@ -236,16 +236,6 @@ export function VariableBoxContent({
 
     let newIndex = currentFocusedItemIndex ?? 1;
 
-    if (key === ' ') {
-      const item = items[currentFocusedItemIndex ?? 0];
-      if (item && item.type === 'value' && item.value) {
-        onChangeCheckbox(varId, item.value.code);
-      }
-      if (item && item.type === 'mixedCheckbox') {
-        onChangeMixedCheckbox(varId, allValuesSelected, searchedValues);
-      }
-    }
-
     if (isSearchFocused && key === 'ArrowDown') {
       setCurrentFocusedItemIndex(1);
       newIndex = 1;
@@ -292,7 +282,7 @@ export function VariableBoxContent({
       }
 
       if (elementId) {
-        const element = document.getElementById(elementId);
+        const element = document.getElementById(elementId + uniqueId);
         if (element) {
           element.focus();
         }
@@ -338,9 +328,10 @@ export function VariableBoxContent({
     if (item.type === 'search') {
       return (
         <div
-          id={`${varId}-search`}
+          id={`${varId}-search` + uniqueId}
           tabIndex={-1}
           className={classes['focusableItem']}
+          onFocus={() => setCurrentFocusedItemIndex(0)}
         >
           <Search
             ref={searchRef}
@@ -377,15 +368,22 @@ export function VariableBoxContent({
             style={{ height: initiallyHadSevenOrMoreValues ? '4px' : '0px' }}
           ></div>
           <div
-            id={varId}
+            id={varId + uniqueId}
             tabIndex={-1}
-            onFocus={(event) => event.target.childNodes[0].focus()}
+            onFocus={(event) => {
+              event.target.childNodes[0].focus();
+              if (hasSevenOrMoreValues) {
+                setCurrentFocusedItemIndex(1);
+              } else {
+                setCurrentFocusedItemIndex(0);
+              }
+            }}
             className={cl(classes['focusableItem'], {
               [classes['mixedCheckbox']]: true,
             })}
           >
             <MixedCheckbox
-              id={varId}
+              id={varId + uniqueId}
               text={mixedCheckboxText}
               value={allValuesSelected}
               onChange={() =>
@@ -407,13 +405,15 @@ export function VariableBoxContent({
       return (
         <>
           <div
-            id={value.code}
+            id={value.code + uniqueId}
             tabIndex={-1}
-            onFocus={(event) => event.target.childNodes[0].focus()}
+            onFocus={(event) => {
+              event.target.childNodes[0].focus();
+            }}
             className={cl(classes['focusableItem'])}
           >
             <Checkbox
-              id={value.code}
+              id={value.code + uniqueId}
               key={varId + value.code}
               tabIndex={-1}
               value={

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -86,7 +86,7 @@ export function VariableBoxContent({
     number | null
   >(null);
   const [items, setItems] = useState<{ type: string; value?: Value }[]>([]);
-  const [uniqueId] = useState(Math.random());
+  const [uniqueId] = useState(() => crypto.randomUUID());
   const valuesOnlyList = useRef<HTMLDivElement>(null);
   const hasCodeLists = codeLists && codeLists.length > 0;
   const hasSevenOrMoreValues = values && values.length > 6;
@@ -383,7 +383,7 @@ export function VariableBoxContent({
             })}
           >
             <MixedCheckbox
-              id={varId + uniqueId}
+              id={varId + uniqueId + 'mixedCheckbox'}
               text={mixedCheckboxText}
               value={allValuesSelected}
               onChange={() =>
@@ -413,7 +413,7 @@ export function VariableBoxContent({
             className={cl(classes['focusableItem'])}
           >
             <Checkbox
-              id={value.code + uniqueId}
+              id={value.code + uniqueId + 'checkbox'}
               key={varId + value.code}
               tabIndex={-1}
               value={


### PR DESCRIPTION
Focus should now look as intended in variablebox
Focus should now work as intended in variablebox
Fixed pretty unfortunate bug in which colliding Ids made the focus jump from one variablebox to another