### PR TITLE
Fix/cleanup tests output to increase readability

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.spec.tsx
@@ -26,13 +26,12 @@ describe('Checkbox', () => {
         text="Variable 1"
         onChange={(val) => {
           selected = val;
-          console.log('inside onchange');
         }}
         value={selected}
       />,
     );
 
-    baseElement.querySelector('#test').click();
+    (baseElement.querySelector('#test') as HTMLElement)?.click();
 
     expect(selected).toBe(true);
   });

--- a/packages/pxweb2-ui/src/lib/components/Radio/Radio.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Radio/Radio.spec.tsx
@@ -10,7 +10,15 @@ const options = [
 
 describe('Radio', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<Radio options={options} name="Radio1" />);
+    const { baseElement } = render(
+      <Radio
+        options={options}
+        name="Radio1"
+        onChange={() => {
+          return;
+        }}
+      />,
+    );
     expect(baseElement).toBeTruthy();
   });
 });

--- a/packages/pxweb2-ui/src/lib/components/Spinner/Spinner.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Spinner/Spinner.tsx
@@ -82,14 +82,14 @@ export function Spinner({
         cy="25"
         r={Radius}
         className={cl(classes[`path-stroke-background-${variant}`])}
-        stroke-width={StrokeWidth}
+        strokeWidth={StrokeWidth}
       ></circle>
       <circle
         cx="25"
         cy="25"
         r={Radius}
         className={cl(classes[`path-stroke-circle-${variant}`])}
-        stroke-width={StrokeWidth}
+        strokeWidth={StrokeWidth}
       ></circle>
     </svg>
   );

--- a/packages/pxweb2/src/app/context/AccessibilityProvider.tsx
+++ b/packages/pxweb2/src/app/context/AccessibilityProvider.tsx
@@ -56,7 +56,10 @@ export const AccessibilityProvider = ({
 
   // Debug logging in development
   useEffect(() => {
-    if (location.href.includes('localhost')) {
+    if (
+      location.href.includes('localhost') &&
+      process.env.NODE_ENV !== 'test'
+    ) {
       console.log('PxWeb2 - a11y - Modals (Stack):', modals);
       console.log('PxWeb2 - a11y - Focus overrides:', focusOverrides);
     }


### PR DESCRIPTION
This fixes the spam we have when we run tests in the terminal. It fixes the issues in the test files, that caused said spam. And it adds a check for if the code is run during tests to the console.logging in the accessibility provider.