### PR TITLE
Fix PxWeb2 font-family and font-weights

### DIFF
--- a/packages/pxweb2-ui/.storybook/main.js
+++ b/packages/pxweb2-ui/.storybook/main.js
@@ -22,5 +22,8 @@ const config = {
     name: getAbsolutePath('@storybook/react-vite'),
     options: {},
   },
+  staticDirs: [
+    {from: './../src/lib/fonts/', to: 'fonts'},
+  ],
 };
 export default config;

--- a/packages/pxweb2-ui/.storybook/main.js
+++ b/packages/pxweb2-ui/.storybook/main.js
@@ -23,7 +23,7 @@ const config = {
     options: {},
   },
   staticDirs: [
-    {from: './../src/lib/fonts/', to: 'fonts'},
+    {from: './../src/lib/fonts/', to: 'fonts'}, // Load static font files into storybook/chromatic
   ],
 };
 export default config;

--- a/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.module.scss
@@ -64,14 +64,15 @@
 .label {
   margin-top: 10px;
   margin-bottom: 10px;
-  font-family: PxWeb-font-400;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 400;
   letter-spacing: 0em;
   color: var(--px-color-text-default);
   line-height: 1.5rem;
   font-size: 1rem;
 }
 .strong {
-  font-family: PxWeb-font-700;
+  font-weight: 700;
 }
 
 .mixedCheckbox {

--- a/packages/pxweb2-ui/src/lib/components/Table/Table.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Table/Table.module.scss
@@ -43,7 +43,8 @@
     }
   }
   thead th {
-    font-family: PxWeb-font-700, sans-serif;
+    font-family: PxWeb-font, sans-serif;
+    font-weight: 700;
   }
   thead tr:last-child th {
     text-align: end;
@@ -152,7 +153,8 @@
   }
   tr.firstdim th {
     border-top: 1px solid var(--px-color-border-default);
-    font-family: PxWeb-font-700, sans-serif;
+    font-family: PxWeb-font, sans-serif;
+    font-weight: 700;
     @media screen and (min-width: fixed.$breakpoints-small-min-width) {
       border-top: 2px solid var(--px-color-border-default);
     }
@@ -163,7 +165,8 @@
   }
   tr.firstdim td {
     border-top: 1px solid var(--px-color-border-default);
-    font-family: PxWeb-font-700, sans-serif;
+    font-family: PxWeb-font, sans-serif;
+    font-weight: 700;
     @media screen and (min-width: fixed.$breakpoints-small-min-width) {
       border-top: 2px solid var(--px-color-border-default);
     }
@@ -227,7 +230,8 @@
     border-right: none;
     border-bottom: none;
     border-top: none;
-    font-family: PxWeb-font-700, sans-serif;
+    font-family: PxWeb-font, sans-serif;
+    font-weight: 700;
   }
 
   .mobileRowHeadThirdLastStub > th,

--- a/packages/pxweb2-ui/src/lib/components/Typography/BodyShort/BodyShort.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Typography/BodyShort/BodyShort.module.scss
@@ -38,12 +38,12 @@
 }
 
 .weight-regular {
-  font-family: PxWeb-font-400;
+  font-family: PxWeb-font, sans-serif;
   font-weight: 400;
 }
 
 .weight-bold {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
   font-weight: 700;
 }
 

--- a/packages/pxweb2-ui/src/lib/components/Typography/Ingress/Ingress.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Typography/Ingress/Ingress.module.scss
@@ -23,11 +23,11 @@
   color: var(--px-color-text-subtle);
 }
 .weight-regular {
-  font-family: PxWeb-font-400;
+  font-family: PxWeb-font, sans-serif;
   font-weight: 400;
 }
 .weight-bold {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
   font-weight: 700;
 }
 .spacing {

--- a/packages/pxweb2-ui/src/lib/global.scss
+++ b/packages/pxweb2-ui/src/lib/global.scss
@@ -8,14 +8,17 @@ body {
 }
 
 @font-face {
-  font-family: 'PxWeb-font-400';
-  src: url('./fonts/PxWeb-font-400.ttf') format('truetype');
+  font-family: 'PxWeb-font';
+  src: url('/fonts/PxWeb-font-400.ttf') format('truetype');
+  font-weight: 400;
 }
 @font-face {
-  font-family: 'PxWeb-font-500';
-  src: url('./fonts/PxWeb-font-500.ttf') format('truetype');
+  font-family: 'PxWeb-font';
+  src: url('/fonts/PxWeb-font-500.ttf') format('truetype');
+  font-weight: 500;
 }
 @font-face {
-  font-family: 'PxWeb-font-700';
-  src: url('./fonts/PxWeb-font-700.ttf') format('truetype');
+  font-family: 'PxWeb-font';
+  src: url('/fonts/PxWeb-font-700.ttf') format('truetype');
+  font-weight: 700;
 }

--- a/packages/pxweb2-ui/src/lib/text-styles.scss
+++ b/packages/pxweb2-ui/src/lib/text-styles.scss
@@ -2,128 +2,128 @@
 
 /* Label/Small */
 .label-small {
-  font-family: PxWeb-font-500;
-  font-style: normal;
+  font-family: PxWeb-font, sans-serif;
   font-weight: 500;
+  font-style: normal;
   font-size: 0.875rem;
   line-height: 1.25rem; /* 125% */
 }
 
 /* Label/Medium */
 .label-medium {
-  font-family: PxWeb-font-500;
-  font-style: normal;
+  font-family: PxWeb-font, sans-serif;
   font-weight: 500;
+  font-style: normal;
   font-size: 1rem;
   line-height: 1.5rem; /* 150% */
 }
 
 /* BodyLong/Medium */
 .bodylong-medium {
-  font-family: PxWeb-font-400;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 400;
   font-size: 1rem;
   font-style: normal;
-  font-weight: 400;
   line-height: 1.75rem; /* 175% */
 }
 
 /* BodyLong/Medium/strong */
 .bodylong-medium-bold {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 1rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 1.75rem; /* 175% */
 }
 
 /* BodyLong/Small */
 .bodylong-small {
-  font-family: PxWeb-font-400;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 400;
   font-size: 0.875rem;
   font-style: normal;
-  font-weight: 400;
   line-height: 1.5rem; /* 150% */
 }
 
 /* BodyLong/Small/strong */
 .bodylong-small-bold {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 0.875rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 1.5rem; /* 150% */
 }
 
 /* BodyShort/medium */
 .bodyshort-medium {
-  font-family: PxWeb-font-400;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 400;
   font-size: 1rem;
   font-style: normal;
-  font-weight: 400;
   line-height: 1.5rem; /* 150% */
 }
 
 /* BodyShort/medium/strong */
 .bodyshort-medium-bold {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 1rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 1.5rem; /* 150% */
 }
 
 /* BodyShort/Small */
 .bodyshort-small {
-  font-family: PxWeb-font-400;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 400;
   font-size: 0.875rem;
   font-style: normal;
-  font-weight: 400;
   line-height: 1.25rem; /* 125% */
 }
 
 /* BodyShort/Small/strong */
 .bodyshort-small-bold {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 0.875rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 1.25rem; /* 125% */
 }
 
 /* Heading/Desktop/XSmall */
 .heading-xsmall {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 1rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 1.625rem; /* 162.5% */
 }
 
 /* Heading/Desktop/Small */
 .heading-small {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 1.25rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 1.75rem; /* 175% */
   letter-spacing: 0.00625rem;
 }
 
 /* Heading/Desktop/Medium */
 .heading-medium {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 1.5rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 2.25rem; /* 225% */
 }
 
 /* Heading/Desktop/Large */
 .heading-large {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 2rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 2.75rem; /* 275% */
 
   /* Heading/Mobile/Large */
@@ -135,10 +135,10 @@
 
 /* Heading/Desktop/XLarge */
 .heading-xlarge {
-  font-family: PxWeb-font-700;
+  font-family: PxWeb-font, sans-serif;
+  font-weight: 700;
   font-size: 2.5rem;
   font-style: normal;
-  font-weight: 700;
   line-height: 3.5rem; /* 350% */
 
   /* Heading/Mobile/XLarge */

--- a/packages/pxweb2/src/styles.scss
+++ b/packages/pxweb2/src/styles.scss
@@ -8,14 +8,17 @@ body {
 }
 
 @font-face {
-  font-family: 'PxWeb-font-400';
+  font-family: 'PxWeb-font';
   src: url('/fonts/PxWeb-font-400.ttf') format('truetype');
+  font-weight: 400;
 }
 @font-face {
-  font-family: 'PxWeb-font-500';
+  font-family: 'PxWeb-font';
   src: url('/fonts/PxWeb-font-500.ttf') format('truetype');
+  font-weight: 500;
 }
 @font-face {
-  font-family: 'PxWeb-font-700';
+  font-family: 'PxWeb-font';
   src: url('/fonts/PxWeb-font-700.ttf') format('truetype');
+  font-weight: 700;
 }


### PR DESCRIPTION
This fixes how we create our own font-family in the project. The font-family was initially created so we had 3, one for each font-weight. This leads to issues with browser user-agents, that automatically try to add boldness etc. to h1 tags and similar. For us, all the titles were too bold. Now the font-families are merged into one, with the font-weights: 400, 500 and 700. The site looks the same in chrome and safari.