### PR TITLE
Prevent autoscrolling when opening variableboxes

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.tsx
@@ -40,6 +40,8 @@ export function VariableBoxHeader({
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault(); // Prevent scrolling with spacebar
+
       setIsOpen(!isOpen);
     }
   }


### PR DESCRIPTION
Since we have implemented custom keyboard navigation for opening/closing the variableboxes, we have to prevent that function from triggering the normal auto-scrolling for the spacebar.