### PR TITLE
Add keyboard nav and focus to the Select in VarBox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ theme/variables.css
 
 vite.config.*.timestamp*
 *storybook.log
+
+# AI
+.qodo

--- a/packages/pxweb2-ui/src/lib/components/Modal/Modal.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Modal/Modal.spec.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import Modal from './Modal';
 import { mockHTMLDialogElement } from '../../util/test-utils';
@@ -65,5 +66,126 @@ describe('Modal', () => {
 
     expect(saveButton?.textContent).toBe('custom.confirm');
     expect(cancelButton?.textContent).toBe('custom.cancel');
+  });
+
+  it('should call onClose with correct parameters when clicking confirm button', () => {
+    const onCloseMock = vi.fn();
+
+    render(
+      <Modal isOpen={true} onClose={onCloseMock}>
+        <span>test</span>
+      </Modal>,
+    );
+
+    const confirmButton = screen.getByText('common.generic_buttons.save');
+
+    fireEvent.click(confirmButton);
+
+    expect(onCloseMock).toHaveBeenCalledWith(true);
+  });
+
+  it('should call onClose with correct parameters when clicking cancel button', () => {
+    const onCloseMock = vi.fn();
+
+    render(
+      <Modal isOpen={true} onClose={onCloseMock}>
+        <span>test</span>
+      </Modal>,
+    );
+
+    const cancelButton = screen.getByText('common.generic_buttons.cancel');
+
+    fireEvent.click(cancelButton);
+
+    expect(onCloseMock).toHaveBeenCalledWith(false);
+  });
+
+  it('should call onClose with correct parameters when clicking X button', () => {
+    const onCloseMock = vi.fn();
+
+    render(
+      <Modal isOpen={true} onClose={onCloseMock}>
+        <span>test</span>
+      </Modal>,
+    );
+
+    // Get the X button specifically by finding it within the xMarkWrapper div
+    const xButton = screen.getByLabelText('common.generic_buttons.cancel', {
+      selector: `div[class*="xMarkWrapper"] button`,
+    });
+
+    fireEvent.click(xButton);
+
+    expect(onCloseMock).toHaveBeenCalledWith(false);
+  });
+
+  it('should call onClose with correct parameters when pressing Escape', () => {
+    const onCloseMock = vi.fn();
+
+    render(
+      <Modal isOpen={true} onClose={onCloseMock}>
+        <span>test</span>
+      </Modal>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onCloseMock).toHaveBeenCalledWith(false, 'Escape');
+  });
+
+  it('should render label and heading when provided', () => {
+    render(
+      <Modal isOpen={true} label="Test Label" heading="Test Heading">
+        <span>test</span>
+      </Modal>,
+    );
+
+    expect(screen.getByText('Test Label')).toBeDefined();
+    expect(screen.getByText('Test Heading')).toBeDefined();
+  });
+
+  it('should handle Enter key press on buttons', () => {
+    const onCloseMock = vi.fn();
+
+    render(
+      <Modal isOpen={true} onClose={onCloseMock}>
+        <span>test</span>
+      </Modal>,
+    );
+
+    const confirmButton = screen.getByText('common.generic_buttons.save');
+
+    fireEvent.keyUp(confirmButton, { key: 'Enter' });
+
+    expect(onCloseMock).toHaveBeenCalledWith(true, 'Enter');
+  });
+
+  it('should update body overflow style when opening and closing', () => {
+    const { rerender } = render(
+      <Modal isOpen={true}>
+        <span>test</span>
+      </Modal>,
+    );
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    rerender(
+      <Modal isOpen={false}>
+        <span>test</span>
+      </Modal>,
+    );
+
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('should apply custom className when provided', () => {
+    const { container } = render(
+      <Modal isOpen={true} className="custom-class">
+        <span>test</span>
+      </Modal>,
+    );
+    const dialog = container.querySelector('dialog');
+
+    expect(dialog?.className).includes('custom-class');
   });
 });

--- a/packages/pxweb2-ui/src/lib/components/Modal/Modal.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Modal/Modal.tsx
@@ -70,15 +70,22 @@ export function Modal({
     updated: boolean,
     event?: KeyboardEvent | MouseEvent,
   ) => {
-    if (event && (event as KeyboardEvent).key) {
-      const keyPress = (event as KeyboardEvent).key;
+    // If the event is passed, it means that the user pressed a key
+    if (event) {
+      const keyPress = (event as KeyboardEvent)?.key;
+      const isValidKeyPress = keyPress === 'Enter' || keyPress === ' ';
 
-      if (onClose && (keyPress === ' ' || keyPress === 'Enter')) {
+      if (onClose && isValidKeyPress) {
         setWindowScroll(true);
         onClose(updated, keyPress);
         setIsModalOpen(false); // Ensure that the modal's state is updated when it's closed
+
+        return;
       }
-    } else if (onClose) {
+    }
+
+    // If the event is not passed, it means that the user clicked on the button with the mouse
+    if (!event && onClose) {
       setWindowScroll(true);
       onClose(updated);
       setIsModalOpen(false); // Ensure that the modal's state is updated when it's closed
@@ -110,8 +117,14 @@ export function Modal({
               variant="tertiary"
               size="small"
               icon="XMark"
+              type="button"
+              onClick={() => handleCloseModal(false)}
               onKeyUp={(event) => handleCloseModal(false, event)}
-              onClick={(event) => handleCloseModal(false, event)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault(); // Prevent the default behavior of the Enter key on buttons (turns it into a mouse click event)
+                }
+              }}
               aria-label={cancelLabelValue}
             ></Button>
           </div>
@@ -126,8 +139,14 @@ export function Modal({
           <Button
             variant="primary"
             size="medium"
+            type="button"
+            onClick={() => handleCloseModal(true)}
             onKeyUp={(event) => handleCloseModal(true, event)}
-            onClick={(event) => handleCloseModal(true, event)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault(); // Prevent the default behavior of the Enter key on buttons (turns it into a mouse click event)
+              }
+            }}
             aria-label={confirmLabelValue}
           >
             {confirmLabelValue}
@@ -135,8 +154,14 @@ export function Modal({
           <Button
             variant="secondary"
             size="medium"
+            type="button"
+            onClick={() => handleCloseModal(false)}
             onKeyUp={(event) => handleCloseModal(false, event)}
-            onClick={(event) => handleCloseModal(false, event)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault(); // Prevent the default behavior of the Enter key on buttons (turns it into a mouse click event)
+              }
+            }}
             aria-label={cancelLabelValue}
           >
             {cancelLabelValue}

--- a/packages/pxweb2-ui/src/lib/components/Modal/Modal.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Modal/Modal.tsx
@@ -75,26 +75,32 @@ export function Modal({
 
   const handleCloseModal = useCallback(
     (updated: boolean, event?: ReactKeyboardEvent | MouseEvent) => {
-      // If the event is passed, it means that the user pressed a key
-      if (event) {
-        const keyPress = (event as ReactKeyboardEvent)?.key;
+      const handleKeyboardEvent = (
+        updated: boolean,
+        event: ReactKeyboardEvent,
+      ) => {
+        const keyPress = event.key;
         const isValidKeyPress =
           keyPress === 'Enter' || keyPress === ' ' || keyPress === 'Escape';
 
         if (onClose && isValidKeyPress) {
           setWindowScroll(true);
           onClose(updated, keyPress);
-          setIsModalOpen(false); // Ensure that the modal's state is updated when it's closed
-
-          return;
+          setIsModalOpen(false);
         }
-      }
+      };
 
-      // If the event is not passed, it means that the user clicked on the button with the mouse
-      if (!event && onClose) {
-        setWindowScroll(true);
-        onClose(updated);
-        setIsModalOpen(false); // Ensure that the modal's state is updated when it's closed
+      const handleMouseEvent = (updated: boolean) => {
+        if (onClose) {
+          setWindowScroll(true);
+          onClose(updated);
+          setIsModalOpen(false);
+        }
+      };
+      if (event) {
+        handleKeyboardEvent(updated, event as ReactKeyboardEvent);
+      } else {
+        handleMouseEvent(updated);
       }
     },
     [onClose],

--- a/packages/pxweb2-ui/src/lib/components/Radio/Radio.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Radio/Radio.spec.tsx
@@ -1,24 +1,180 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
 
-import Radio from './Radio';
-
-const options = [
-  { label: 'Option 1', value: '1' },
-  { label: 'Option 2', value: '2' },
-  { label: 'Option 3', value: '3' },
-];
+import Radio, { SelectOption } from './Radio';
 
 describe('Radio', () => {
-  it('should render successfully', () => {
-    const { baseElement } = render(
-      <Radio
-        options={options}
-        name="Radio1"
-        onChange={() => {
-          return;
-        }}
-      />,
-    );
-    expect(baseElement).toBeTruthy();
+  const mockOptions: SelectOption[] = [
+    { label: 'Option 1', value: '1' },
+    { label: 'Option 2', value: '2' },
+    { label: 'Option 3', value: '3' },
+  ];
+
+  const defaultProps = {
+    name: 'test-radio',
+    options: mockOptions,
+    onChange: () => {
+      return;
+    },
+  };
+
+  describe('rendering', () => {
+    it('should render all options', () => {
+      render(<Radio {...defaultProps} />);
+
+      mockOptions.forEach((option) => {
+        expect(screen.getByLabelText(option.label)).toBeDefined();
+      });
+    });
+
+    it('should render with default variant', () => {
+      const { container } = render(<Radio {...defaultProps} />);
+
+      const radioGroup = container.querySelector('[class*="default"]');
+      expect(radioGroup).toBeDefined();
+    });
+
+    it('should render with inModal variant', () => {
+      const { container } = render(
+        <Radio {...defaultProps} variant="inModal" />,
+      );
+
+      const radioGroup = container.querySelector('[class*="inModal"]');
+      expect(radioGroup).toBeDefined();
+    });
+  });
+
+  describe('selection behavior', () => {
+    it('should mark the selected option as checked', () => {
+      render(<Radio {...defaultProps} selectedOption={mockOptions[1].value} />);
+
+      const selectedRadio = screen.getByLabelText(
+        mockOptions[1].label,
+      ) as HTMLInputElement;
+      expect(selectedRadio.checked).toBe(true);
+    });
+
+    it('should call onChange when selecting an option', () => {
+      const mockOnChange = vi.fn();
+      render(<Radio {...defaultProps} onChange={mockOnChange} />);
+
+      const radio = screen.getByLabelText(mockOptions[0].label);
+      fireEvent.click(radio);
+
+      expect(mockOnChange).toHaveBeenCalled();
+    });
+
+    it('should have correct name attribute on all inputs', () => {
+      render(<Radio {...defaultProps} />);
+
+      const radioInputs = screen.getAllByRole('radio');
+      radioInputs.forEach((input) => {
+        expect(input).toHaveAttribute('name', defaultProps.name);
+      });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should forward ref to selected radio input', () => {
+      const ref = vi.fn();
+      render(
+        <Radio
+          {...defaultProps}
+          selectedOption={mockOptions[1].value}
+          ref={ref}
+        />,
+      );
+
+      expect(ref).toHaveBeenCalled();
+    });
+
+    it('should have proper attributes for accessibility', () => {
+      render(<Radio {...defaultProps} />);
+
+      const radioInputs = screen.getAllByRole('radio');
+
+      radioInputs.forEach((input, index) => {
+        expect(input).toHaveAttribute('type', 'radio');
+        expect(input).toHaveAttribute('id', mockOptions[index].value);
+        expect(input).toHaveAttribute('value', mockOptions[index].value);
+      });
+    });
+
+    it('should allow keyboard interaction', () => {
+      const mockOnChange = vi.fn();
+      render(<Radio {...defaultProps} onChange={mockOnChange} />);
+
+      const firstRadio = screen.getByLabelText(mockOptions[0].label);
+      firstRadio.focus();
+      fireEvent.click(firstRadio);
+
+      expect(mockOnChange).toHaveBeenCalled();
+    });
+
+    it('should be keyboard accessible', () => {
+      render(<Radio {...defaultProps} />);
+
+      const firstRadio = screen.getByLabelText(mockOptions[0].label);
+
+      // Verify the radio can receive focus
+      firstRadio.focus();
+      expect(firstRadio).toHaveFocus();
+
+      // Verify it has the correct role
+      expect(firstRadio).toHaveAttribute('type', 'radio');
+    });
+  });
+
+  describe('group behavior', () => {
+    it('should call onChange with correct values when selecting different options', () => {
+      const mockOnChange = vi.fn();
+      render(<Radio {...defaultProps} onChange={mockOnChange} />);
+
+      const radio1 = screen.getByLabelText(mockOptions[0].label);
+      const radio2 = screen.getByLabelText(mockOptions[1].label);
+
+      fireEvent.click(radio1);
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({
+            value: mockOptions[0].value,
+          }),
+        }),
+      );
+
+      fireEvent.click(radio2);
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({
+            value: mockOptions[1].value,
+          }),
+        }),
+      );
+    });
+
+    it('should reflect selected state based on selectedOption prop', () => {
+      const { rerender } = render(
+        <Radio {...defaultProps} selectedOption={mockOptions[0].value} />,
+      );
+
+      const radio1 = screen.getByLabelText(
+        mockOptions[0].label,
+      ) as HTMLInputElement;
+      const radio2 = screen.getByLabelText(
+        mockOptions[1].label,
+      ) as HTMLInputElement;
+
+      expect(radio1.checked).toBe(true);
+      expect(radio2.checked).toBe(false);
+
+      // Update selected option
+      rerender(
+        <Radio {...defaultProps} selectedOption={mockOptions[1].value} />,
+      );
+
+      expect(radio1.checked).toBe(false);
+      expect(radio2.checked).toBe(true);
+    });
   });
 });

--- a/packages/pxweb2-ui/src/lib/components/Radio/Radio.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Radio/Radio.tsx
@@ -1,6 +1,7 @@
-import classes from './Radio.module.scss';
 import cl from 'clsx';
-import React from 'react';
+import React, { forwardRef } from 'react';
+
+import classes from './Radio.module.scss';
 
 export type SelectOption = {
   label: string;
@@ -16,37 +17,34 @@ export interface RadioProps
   selectedOption?: string;
 }
 
-export function Radio({
-  variant = 'default',
-  name,
-  options,
-  onChange,
-  selectedOption,
-}: RadioProps) {
-  return (
-    <div className={cl(classes.radioGroup)}>
-      {options.map((option) => (
-        <label
-          className={cl(classes.container, classes[`bodyshort-medium`])}
-          key={option.value}
-        >
-          <div className={cl(classes[variant], classes.divider)}>
-            <input
-              className={cl(classes[variant])}
-              type="radio"
-              id={option.value}
-              name={name}
-              value={option.value}
-              key={option.value}
-              onChange={onChange}
-              checked={option.value === selectedOption}
-            />
-            {option.label}
-          </div>
-        </label>
-      ))}
-    </div>
-  );
-}
+export const Radio = forwardRef<HTMLInputElement, Readonly<RadioProps>>(
+  ({ variant = 'default', name, options, onChange, selectedOption }, ref) => {
+    return (
+      <div className={cl(classes.radioGroup)}>
+        {options.map((option) => (
+          <label
+            className={cl(classes.container, classes[`bodyshort-medium`])}
+            key={option.value}
+          >
+            <div className={cl(classes[variant], classes.divider)}>
+              <input
+                className={cl(classes[variant])}
+                type="radio"
+                id={option.value}
+                name={name}
+                value={option.value}
+                key={option.value}
+                onChange={onChange}
+                checked={option.value === selectedOption}
+                ref={option.value === selectedOption ? ref : null}
+              />
+              {option.label}
+            </div>
+          </label>
+        ))}
+      </div>
+    );
+  },
+);
 
 export default Radio;

--- a/packages/pxweb2-ui/src/lib/components/Select/Select.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Select/Select.module.scss
@@ -54,6 +54,7 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
   flex: 1 0 0;
 }
 
@@ -92,7 +93,8 @@
     outline: 2px solid var(--px-color-border-selected);
   }
 
-  &:focus-visible {
+  &:focus,
+  :focus-visible {
     outline: 3px solid var(--px-color-border-focus-outline);
     outline-offset: 3px;
     box-shadow: inset 0 0 0 3px var(--px-color-border-focus-boxshadow);
@@ -124,6 +126,7 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
   align-self: stretch;
 }
 

--- a/packages/pxweb2-ui/src/lib/components/Select/Select.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Select/Select.spec.tsx
@@ -1,28 +1,206 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '@testing-library/jest-dom';
 
 import Select, { SelectOption } from './Select';
-
-const options: SelectOption[] = [
-  { label: 'Option 1', value: '1' },
-  { label: 'Option 2', value: '2' },
-  { label: 'Option 3', value: '3' },
-];
-
-function selectedOptionChanged(selectedItem: SelectOption | undefined) {
-  selectedItem
-    ? console.log('Selected option: ' + selectedItem.label)
-    : console.log('No option selected');
-}
+import { mockHTMLDialogElement } from '../../util/test-utils';
 
 describe('Select', () => {
-  it('should render successfully', () => {
-    const { baseElement } = render(
-      <Select
-        label="Label"
-        options={options}
-        onChange={selectedOptionChanged}
-      />,
-    );
-    expect(baseElement).toBeTruthy();
+  const mockOptions: SelectOption[] = [
+    { label: 'Option 1', value: '1' },
+    { label: 'Option 2', value: '2' },
+    { label: 'Option 3', value: '3' },
+  ];
+
+  const mockAddModal = vi.fn();
+  const mockRemoveModal = vi.fn();
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    mockHTMLDialogElement();
+    vi.clearAllMocks();
+  });
+
+  describe('DefaultSelect variant', () => {
+    it('should render with required props', () => {
+      render(
+        <Select
+          label="Test Select"
+          options={mockOptions}
+          onChange={mockOnChange}
+          addModal={mockAddModal}
+          removeModal={mockRemoveModal}
+        />,
+      );
+
+      expect(screen.getByText('Test Select')).toBeDefined();
+    });
+
+    it('should hide label when hideLabel is true', () => {
+      const { container } = render(
+        <Select
+          label="Test Select"
+          hideLabel={true}
+          options={mockOptions}
+          onChange={mockOnChange}
+          addModal={mockAddModal}
+          removeModal={mockRemoveModal}
+        />,
+      );
+
+      const labelWrapper = container.querySelector('[class*="visuallyHidden"]');
+      expect(labelWrapper).toBeDefined();
+    });
+
+    it('should display placeholder when no option is selected', () => {
+      const placeholder = 'Select an option';
+      render(
+        <Select
+          label="Test Select"
+          placeholder={placeholder}
+          options={mockOptions}
+          onChange={mockOnChange}
+          addModal={mockAddModal}
+          removeModal={mockRemoveModal}
+        />,
+      );
+
+      expect(screen.getByText(placeholder)).toBeDefined();
+    });
+
+    it('should display selected option when provided', () => {
+      render(
+        <Select
+          label="Test Select"
+          options={mockOptions}
+          selectedOption={mockOptions[0]}
+          onChange={mockOnChange}
+          addModal={mockAddModal}
+          removeModal={mockRemoveModal}
+        />,
+      );
+
+      expect(screen.getByText(mockOptions[0].label)).toBeDefined();
+    });
+  });
+
+  describe('VariableBoxSelect variant', () => {
+    const defaultProps = {
+      label: 'Test Select',
+      options: mockOptions,
+      onChange: mockOnChange,
+      addModal: mockAddModal,
+      removeModal: mockRemoveModal,
+      variant: 'inVariableBox' as const,
+    };
+
+    it('should render with required props', () => {
+      render(<Select {...defaultProps} />);
+      expect(screen.getByText('Test Select')).toBeDefined();
+    });
+
+    it('should register modal handlers on mount', () => {
+      render(<Select {...defaultProps} />);
+
+      const select = screen.getByRole('button');
+      fireEvent.click(select);
+
+      expect(mockAddModal).toHaveBeenCalledWith(
+        'VariableBoxSelect',
+        expect.any(Function),
+      );
+    });
+
+    it('should remove modal handlers on unmount', () => {
+      const { unmount } = render(<Select {...defaultProps} />);
+
+      const select = screen.getByRole('button');
+      fireEvent.click(select);
+      unmount();
+
+      expect(mockRemoveModal).toHaveBeenCalledWith('VariableBoxSelect');
+    });
+
+    it('should display selected option when provided', () => {
+      render(<Select {...defaultProps} selectedOption={mockOptions[0]} />);
+
+      expect(screen.getByText(mockOptions[0].label)).toBeDefined();
+    });
+
+    it('should display placeholder when no option is selected', () => {
+      const placeholder = 'Select an option';
+      render(<Select {...defaultProps} placeholder={placeholder} />);
+
+      expect(screen.getByText(placeholder)).toBeDefined();
+    });
+
+    it('should handle spacebar interaction correctly', () => {
+      render(<Select {...defaultProps} />);
+
+      const select = screen.getByRole('button');
+
+      // First press space (keydown)
+      fireEvent.keyDown(select, { key: ' ' });
+
+      // Then release space (keyup) which should open the modal
+      fireEvent.keyUp(select, { key: ' ' });
+
+      // Verify modal is opened
+      expect(screen.getByRole('dialog')).toBeDefined();
+
+      // Verify modal handler was registered
+      expect(mockAddModal).toHaveBeenCalledWith(
+        'VariableBoxSelect',
+        expect.any(Function),
+      );
+    });
+
+    it('should prevent scrolling on spacebar keydown', () => {
+      // Spy on Event.prototype.preventDefault
+      const preventDefaultSpy = vi.spyOn(Event.prototype, 'preventDefault');
+
+      render(<Select {...defaultProps} />);
+
+      const select = screen.getByRole('button');
+
+      // Simulate the keyDown event as React would handle it
+      fireEvent.keyDown(select, {
+        key: ' ',
+        code: 'Space',
+        charCode: 32,
+        keyCode: 32,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      // Assert that preventDefault was called
+      expect(preventDefaultSpy).toHaveBeenCalled();
+
+      // Clean up the spy
+      preventDefaultSpy.mockRestore();
+    });
+
+    it('should handle keyboard interaction for opening modal', () => {
+      render(<Select {...defaultProps} />);
+
+      const select = screen.getByRole('button');
+
+      // Verify keyboard interaction opens modal
+      fireEvent.keyUp(select, { key: ' ' });
+      expect(screen.getByRole('dialog')).toBeDefined();
+      expect(mockAddModal).toHaveBeenCalledWith(
+        'VariableBoxSelect',
+        expect.any(Function),
+      );
+    });
+
+    it('should have correct ARIA attributes', () => {
+      render(<Select {...defaultProps} />);
+
+      const select = screen.getByRole('button');
+
+      expect(select).toHaveAttribute('role', 'button');
+      expect(select).toHaveAttribute('aria-haspopup', 'dialog');
+    });
   });
 });

--- a/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
@@ -212,6 +212,9 @@ function VariableBoxSelect({
     // Set focus back to the select element
     if (selectRef.current && (keyPress === ' ' || keyPress === 'Enter')) {
       programmaticFocusRef.current = true;
+
+      // This hack is needed to ensure that the focus is set correctly,
+      // otherwise the focus will be set during render and be gone before the render phase is done
       setTimeout(() => {
         selectRef.current?.focus();
       }, 0);
@@ -231,11 +234,7 @@ function VariableBoxSelect({
       removeModal('VariableBoxSelect');
     } else {
       addModal('VariableBoxSelect', () => {
-        // This hack is needed to ensure that the focus is set correctly,
-        // otherwise the focus will be set during render and be gone before the render phase is done
-        setTimeout(() => {
-          setIsModalOpen(false);
-        }, 0);
+        setIsModalOpen(false);
       });
 
       // Set focus to the radio button for the selected option when the modal is opened

--- a/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
@@ -1,5 +1,5 @@
 import cl from 'clsx';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 import classes from './Select.module.scss';
 import Label from '../Typography/Label/Label';
@@ -50,12 +50,12 @@ export function Select({
   className = '',
   addModal,
   removeModal,
-}: SelectProps) {
+}: Readonly<SelectProps>) {
   const cssClasses = className.length > 0 ? ' ' + className : '';
 
   return (
     <>
-      {variant && variant === 'default' && (
+      {variant === 'default' && (
         <DefaultSelect
           hideLabel={hideLabel}
           label={label}
@@ -67,7 +67,7 @@ export function Select({
           className={cssClasses}
         />
       )}
-      {variant && variant === 'inVariableBox' && (
+      {variant === 'inVariableBox' && (
         <VariableBoxSelect
           label={label}
           modalHeading={modalHeading}
@@ -108,7 +108,7 @@ function DefaultSelect({
   onChange,
   tabIndex,
   className = '',
-}: DefaultSelectProps) {
+}: Readonly<DefaultSelectProps>) {
   const cssClasses = className.length > 0 ? ' ' + className : '';
 
   return (
@@ -181,7 +181,7 @@ function VariableBoxSelect({
 }: VariableBoxSelectProps) {
   const cssClasses = className.length > 0 ? ' ' + className : '';
 
-  const [isModalOpen, setModalOpen] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [clickedItem, setClickedItem] = useState<SelectOption | undefined>(
     selectedOption,
   );
@@ -189,33 +189,61 @@ function VariableBoxSelect({
   const selectedItem: SelectOption | undefined = selectedOption;
 
   const handleOpenModal = () => {
-    setModalOpen(true);
+    setIsModalOpen(true);
+
     // Reset clicked item to selected item, incase user made changes and then closed the modal
     setClickedItem(selectedItem);
   };
 
-  function handleRadioChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setClickedItem(options.find((option) => option.value === e.target.value));
-  }
-
-  useEffect(() => {
-    if (!isModalOpen) {
-      removeModal('VariableBoxSelect');
-    } else {
-      addModal('VariableBoxSelect', () => {
-        setModalOpen(false);
-      });
+  const handleCloseModal = (updated: boolean, keyPress?: ' ' | 'Enter') => {
+    if (keyPress) {
+      handleCloseModalWithKeyPress(keyPress);
     }
-  }, [removeModal, isModalOpen]);
 
-  const handleCloseModal = (updated: boolean) => {
-    setModalOpen(false);
+    setIsModalOpen(false);
     if (updated) {
       onChange(clickedItem);
     } else {
       setClickedItem(selectedItem);
     }
   };
+
+  function handleCloseModalWithKeyPress(keyPress: ' ' | 'Enter') {
+    // Set focus back to the select element
+    if (selectRef.current && (keyPress === ' ' || keyPress === 'Enter')) {
+      programmaticFocusRef.current = true;
+      setTimeout(() => {
+        selectRef.current?.focus();
+      }, 0);
+    }
+  }
+
+  function handleRadioChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setClickedItem(options.find((option) => option.value === e.target.value));
+  }
+
+  const selectRef = useRef<HTMLDivElement>(null);
+  const selectedRadioOptionRef = useRef<HTMLInputElement>(null);
+  const programmaticFocusRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!isModalOpen) {
+      removeModal('VariableBoxSelect');
+    } else {
+      addModal('VariableBoxSelect', () => {
+        // This hack is needed to ensure that the focus is set correctly,
+        // otherwise the focus will be set during render and be gone before the render phase is done
+        setTimeout(() => {
+          setIsModalOpen(false);
+        }, 0);
+      });
+
+      // Set focus to the radio button for the selected option when the modal is opened
+      if (selectedRadioOptionRef.current) {
+        selectedRadioOptionRef.current.focus();
+      }
+    }
+  }, [removeModal, isModalOpen, addModal]);
 
   return (
     <>
@@ -224,12 +252,23 @@ function VariableBoxSelect({
         tabIndex={tabIndex}
         role="button"
         aria-haspopup="dialog"
-        onClick={() => {
+        ref={selectRef}
+        onClick={(event) => {
+          if (programmaticFocusRef.current) {
+            programmaticFocusRef.current = false;
+            event.preventDefault();
+            return;
+          }
           handleOpenModal();
         }}
         onKeyUp={(event) => {
-          if (event.key === ' ' || event.key === 'Enter') {
+          if (event.key === ' ') {
             handleOpenModal();
+          }
+        }}
+        onKeyDown={(event) => {
+          if (event.key === ' ') {
+            event.preventDefault(); // Prevent scrolling with spacebar
           }
         }}
       >
@@ -264,6 +303,7 @@ function VariableBoxSelect({
             name="option"
             options={options}
             selectedOption={clickedItem?.value}
+            ref={selectedRadioOptionRef}
             onChange={handleRadioChange}
             variant="inModal"
           ></Radio>

--- a/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
@@ -195,7 +195,10 @@ function VariableBoxSelect({
     setClickedItem(selectedItem);
   };
 
-  const handleCloseModal = (updated: boolean, keyPress?: ' ' | 'Enter') => {
+  const handleCloseModal = (
+    updated: boolean,
+    keyPress?: ' ' | 'Enter' | 'Escape',
+  ) => {
     if (keyPress) {
       handleCloseModalWithKeyPress(keyPress);
     }
@@ -208,9 +211,12 @@ function VariableBoxSelect({
     }
   };
 
-  function handleCloseModalWithKeyPress(keyPress: ' ' | 'Enter') {
+  function handleCloseModalWithKeyPress(keyPress: ' ' | 'Enter' | 'Escape') {
     // Set focus back to the select element
-    if (selectRef.current && (keyPress === ' ' || keyPress === 'Enter')) {
+    if (
+      selectRef.current &&
+      (keyPress === ' ' || keyPress === 'Enter' || keyPress === 'Escape')
+    ) {
       programmaticFocusRef.current = true;
 
       // This hack is needed to ensure that the focus is set correctly,

--- a/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Select/Select.tsx
@@ -234,7 +234,10 @@ function VariableBoxSelect({
       removeModal('VariableBoxSelect');
     } else {
       addModal('VariableBoxSelect', () => {
-        setIsModalOpen(false);
+        // Hack for correct focus handling when closing the modal with the escape key
+        setTimeout(() => {
+          setIsModalOpen(false);
+        }, 0);
       });
 
       // Set focus to the radio button for the selected option when the modal is opened


### PR DESCRIPTION
This adds the keyboard navigation and focus marking to the Select and modal in the variableBox. It refocuses the Select when the modal closes.