### PR TITLE
Remove alpine version in nginx-unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . ./
 RUN npm ci && npm run build
 
 # production environment
-FROM nginxinc/nginx-unprivileged:1.27.3-alpine3.20-slim
+FROM nginxinc/nginx-unprivileged:1.27.3-alpine-slim
 COPY --from=build /app/packages/pxweb2/dist /usr/share/nginx/html
 COPY nginx/conf.d/default.conf /etc/nginx/conf.d
 EXPOSE 8080


### PR DESCRIPTION
Dependabot will not upgrade `1.27.3-alpine3.20-slim` to `1.27.4-alpine3.21-slim` so we remove the alpine version number