### PR TITLE
Fix focus styling for the Select

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Select/Select.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Select/Select.module.scss
@@ -93,8 +93,7 @@
     outline: 2px solid var(--px-color-border-selected);
   }
 
-  &:focus,
-  :focus-visible {
+  &:focus-visible {
     outline: 3px solid var(--px-color-border-focus-outline);
     outline-offset: 3px;
     box-shadow: inset 0 0 0 3px var(--px-color-border-focus-boxshadow);


### PR DESCRIPTION
This removes the :focus styling for theVariableBox variant of the Select component. It had the :focus added by mistake, and should only have :focus-visible