### PR TITLE
Add missing (but empty) fields to table testdata

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Table/testData.ts
+++ b/packages/pxweb2-ui/src/lib/components/Table/testData.ts
@@ -60,6 +60,17 @@ function getPxTable(): PxTable {
     variables: variables,
     language: 'en',
     contacts: [],
+    source: '',
+    infofile: '',
+    decimals: 0,
+    officialStatistics: false,
+    notes: [],
+    matrix: '',
+    subjectCode: '',
+    subjectArea: '',
+    aggregationAllowed: false,
+    contents: '',
+    descriptionDefault: false,
   };
   const table: PxTable = {
     metadata: tableMeta,


### PR DESCRIPTION
This adds missing (but empty) fields to the table's testData file. It does not improve/expand/change the tests themselves. This is only to remove some spam during the buildprocess.