### PR TITLE
PxWeb2-540: Fix firefox focusing a container div with kb-nav

### DIFF
--- a/packages/pxweb2/src/app/pages/TableViewer/TableViewer.tsx
+++ b/packages/pxweb2/src/app/pages/TableViewer/TableViewer.tsx
@@ -193,7 +193,8 @@ export function TableViewer() {
     <>
       <SkipToMain ref={skipToMainRef} />
       {!isSmallScreen && <Header />}
-      <div className={styles.navigationAndContentContainer}>
+      {/* tabindex={-1} to fix firefox focusing this div*/}
+      <div className={styles.navigationAndContentContainer} tabIndex={-1}>
         {isSmallScreen ? (
           <>
             <Header />


### PR DESCRIPTION
This fixes the focus order in firefox, when using a keyboard to navigate. Tested and it does not affect Safari or Chrome.