### PR TITLE
Fix/pxweb2-540: Two small fixes for keyboard nav/focus marking

### DIFF
--- a/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.module.scss
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.module.scss
@@ -61,6 +61,11 @@
 
     // Position NavigationDrawer below the header
     top: fixed.$spacing-22;
+
+    &.skipToMainContentVisible {
+      // Calculate position of NavigationDrawer below the header and SkipToMainContent
+      top: calc(fixed.$spacing-22 + var(--skip-to-main-content-height));
+    }
   }
 
   // large and xlarge

--- a/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.tsx
@@ -5,6 +5,7 @@ import { Heading, Icon, Label } from '@pxweb2/pxweb2-ui';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import useAccessibility from '../../context/useAccessibility';
+import useApp from '../../context/useApp';
 
 export interface NavigationDrawerProps {
   children: React.ReactNode;
@@ -23,6 +24,7 @@ export const NavigationDrawer = forwardRef<
 >(({ children, heading, view, openedWithKeyboard, onClose }, ref) => {
   const { t } = useTranslation();
   const { addModal, removeModal } = useAccessibility();
+  const { skipToMainFocused } = useApp();
 
   React.useEffect(() => {
     addModal('NavigationDrawer', () => {
@@ -65,7 +67,9 @@ export const NavigationDrawer = forwardRef<
         className={styles.backdrop}
       ></div>
       <div
-        className={cl(styles.navigationDrawer, styles.fadein)}
+        className={cl(styles.navigationDrawer, styles.fadein, {
+          [styles.skipToMainContentVisible]: skipToMainFocused,
+        })}
         role="region"
         aria-label={heading}
       >

--- a/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.tsx
@@ -41,6 +41,8 @@ export const NavigationDrawer = forwardRef<
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault(); // Prevent scrolling with space
+
       onClose(true, view);
     }
   }
@@ -52,7 +54,7 @@ export const NavigationDrawer = forwardRef<
     ) {
       ref.current?.focus();
     }
-  }, [view]);
+  }, [view, ref]);
 
   React.useEffect(() => {
     if (openedWithKeyboard && ref && typeof ref !== 'function') {


### PR DESCRIPTION
This fixes:

- Position on the NavigationDrawer when skipToMain is focused on mobile
- Autoscrolling when spacebar is used to click the Hide button in the VariableBox