### PR TITLE
Fix the spacing in TableView for main content

### DIFF
--- a/packages/pxweb2/src/app/pages/TableViewer/TableViewer.module.scss
+++ b/packages/pxweb2/src/app/pages/TableViewer/TableViewer.module.scss
@@ -86,5 +86,6 @@
     padding-bottom: fixed.$spacing-6;
     overflow-y: auto;
     scrollbar-width: thin;
+    gap: fixed.$spacing-6;
   }
 }


### PR DESCRIPTION
This re-adds the gap for the contentAndFooterContainer for desktops, to fix the current bug where this gap is missing.