### PR TITLE
Add maxDataCells to web app config

### DIFF
--- a/packages/pxweb2/public/config/config.js
+++ b/packages/pxweb2/public/config/config.js
@@ -9,4 +9,5 @@ window.PxWeb2Config = {
     fallbackLanguage: 'en',
   },
   apiUrl: "https://api.scb.se/OV0104/v2beta/api/v2",
+  maxDataCells: 150000,
 };

--- a/packages/pxweb2/src/app/util/config/config.schema.json
+++ b/packages/pxweb2/src/app/util/config/config.schema.json
@@ -37,7 +37,11 @@
     "apiUrl": {
       "type": "string",
       "description": "The base url for the pxweb api"
+    },
+    "maxDataCells": {
+      "type": "number",
+      "description": "The maximum number of cells allowed to be shown in a table"
     }
   },
-  "required": ["language", "apiUrl"]
+  "required": ["language", "apiUrl", "maxDataCells"]
 }

--- a/packages/pxweb2/src/app/util/config/configType.ts
+++ b/packages/pxweb2/src/app/util/config/configType.ts
@@ -5,4 +5,5 @@ export type Config = {
     fallbackLanguage: string;
   };
   apiUrl: string;
+  maxDataCells: number;
 };


### PR DESCRIPTION
Since we need to have a number that indicates the maximum number of cells we support in the TableView component, and the api-calls it makes. We need to add a field to the web app config that can be configured and used for this purpose.

Later we might add functionality so that this setting can be directly gotten from the api also/instead.

This is only adding this field, not using it anywhere yet. But I tested it and made sure the config validation fails if it is missing.