### PR TITLE
fix: Variable's values' txts when changing codelists

### DIFF
--- a/packages/pxweb2-ui/src/index.ts
+++ b/packages/pxweb2-ui/src/index.ts
@@ -30,6 +30,7 @@ export * from './lib/shared-types/pxTable';
 export * from './lib/shared-types/pxTableMetadata';
 export * from './lib/shared-types/pxTableData';
 export * from './lib/shared-types/value';
+export * from './lib/shared-types/valueDisplayType';
 export * from './lib/shared-types/variable';
 export * from './lib/shared-types/vartypeEnum';
 export * from './lib/util/util';

--- a/packages/pxweb2-ui/src/lib/shared-types/valueDisplayType.ts
+++ b/packages/pxweb2-ui/src/lib/shared-types/valueDisplayType.ts
@@ -1,0 +1,4 @@
+/**
+ * Type for how variable values are displayed (code, value, code + value)
+ */
+export type ValueDisplayType = 'code' | 'value' | 'code_value';

--- a/packages/pxweb2-ui/src/lib/shared-types/variable.ts
+++ b/packages/pxweb2-ui/src/lib/shared-types/variable.ts
@@ -1,6 +1,7 @@
 import { CodeList } from './codelist';
 import { Note } from './note';
 import { Value } from './value';
+import { ValueDisplayType } from './valueDisplayType';
 import { VartypeEnum } from './vartypeEnum';
 
 export type Variable = {
@@ -11,4 +12,5 @@ export type Variable = {
   values: Value[];
   codeLists?: CodeList[];
   notes?: Note[];
+  valueDisplayType: ValueDisplayType;
 };

--- a/packages/pxweb2/src/app/util/utils.spec.ts
+++ b/packages/pxweb2/src/app/util/utils.spec.ts
@@ -1,0 +1,21 @@
+import { getLabelText } from './utils';
+
+describe('getLabelText', () => {
+  it('should return the code when valueDisplayType is "code"', () => {
+    const result = getLabelText('code', '123', 'Label');
+
+    expect(result).toBe('123');
+  });
+
+  it('should return the label when valueDisplayType is "value"', () => {
+    const result = getLabelText('value', '123', 'Label');
+
+    expect(result).toBe('Label');
+  });
+
+  it('should combine and then return the code and the label when valueDisplayType is "code_value"', () => {
+    const result = getLabelText('code_value', '123', 'Label');
+
+    expect(result).toBe('123 Label');
+  });
+});

--- a/packages/pxweb2/src/app/util/utils.ts
+++ b/packages/pxweb2/src/app/util/utils.ts
@@ -1,0 +1,23 @@
+import { ValueDisplayType } from '@pxweb2/pxweb2-ui';
+
+/**
+ * Returns the label text for a value based on the value display type.
+ *
+ * @param valueDisplayType - The value display type for the dimension.
+ * @param code - The code of the value.
+ * @param label - The label of the value.
+ * @returns The label text for the value.
+ */
+export function getLabelText(
+  valueDisplayType: ValueDisplayType,
+  code: string,
+  label: string,
+): string {
+  if (valueDisplayType === 'code') {
+    return code;
+  } else if (valueDisplayType === 'value') {
+    return label;
+  } else {
+    return `${code} ${label}`;
+  }
+}

--- a/packages/pxweb2/src/app/util/utils.ts
+++ b/packages/pxweb2/src/app/util/utils.ts
@@ -15,9 +15,11 @@ export function getLabelText(
 ): string {
   if (valueDisplayType === 'code') {
     return code;
-  } else if (valueDisplayType === 'value') {
-    return label;
-  } else {
-    return `${code} ${label}`;
   }
+  if (valueDisplayType === 'value') {
+    return label;
+  }
+
+  // default to combining code and label
+  return `${code} ${label}`;
 }

--- a/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.spec.ts
+++ b/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.spec.ts
@@ -1,4 +1,4 @@
-import { ClassType, Dataset } from '@pxweb2/pxweb2-api-client';
+import { ClassType, CodeListType, Dataset } from '@pxweb2/pxweb2-api-client';
 import { mapJsonStat2Response } from '../mappers/JsonStat2ResponseMapper';
 
 describe('JsonStat2ResponseMapper', () => {
@@ -60,18 +60,18 @@ describe('JsonStat2ResponseMapper', () => {
               },
 
               codeLists: [
-                // {
-                //   id: 'cd1',
-                //   label: 'Codelist 1',
-                //   type: 'Aggregation',
-                //   links: [],
-                // },
-                //   {
-                //     id: 'cd2',
-                //     label: 'Codelist 2',
-                //     type: CodeListType.VALUESET,
-                //     links: [],
-                //   },
+                {
+                  id: 'cd1',
+                  label: 'Codelist 1',
+                  type: CodeListType.AGGREGATION,
+                  links: [],
+                },
+                {
+                  id: 'cd2',
+                  label: 'Codelist 2',
+                  type: CodeListType.VALUESET,
+                  links: [],
+                },
               ],
             },
           },
@@ -180,7 +180,7 @@ describe('JsonStat2ResponseMapper', () => {
       expect(pxTable.metadata.variables[0].mandatory).equals(true);
       expect(pxTable.metadata.variables[0].codeLists?.length).equals(0);
       expect(pxTable.metadata.variables[1].mandatory).equals(false);
-      expect(pxTable.metadata.variables[1].codeLists?.length).equals(0);
+      expect(pxTable.metadata.variables[1].codeLists?.length).equals(2);
       expect(pxTable.metadata.contacts?.length).equals(2);
       expect(pxTable.metadata.notes?.length).equals(3);
       expect(pxTable.metadata.notes[0].mandatory).equals(true);

--- a/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
+++ b/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
@@ -12,6 +12,7 @@ import {
   setPxTableData,
   Variable,
   Value,
+  ValueDisplayType,
   VartypeEnum,
   PxTableData,
   PxTableMetadata,
@@ -20,6 +21,7 @@ import {
   ContentInfo,
   Note,
 } from '@pxweb2/pxweb2-ui';
+import { getLabelText } from '../app/util/utils';
 
 /**
  * Internal type. Used to keep track of index in json-stat2 value array
@@ -28,11 +30,6 @@ import {
 type counter = {
   number: number;
 };
-
-/**
- * Internal type. Controls how variable values are displayed (code, value, code + value)
- */
-type ValueDisplayType = 'code' | 'value' | 'code_value';
 
 /**
  * Maps a JSONStat2 dataset response to a PxTable object.
@@ -253,6 +250,7 @@ function mapDimension(id: string, dimension: any, role: any): Variable | null {
       values: mapVariableValues(dimension, isContentVariable),
       codeLists: getCodelists(dimension.extension),
       notes: mapNotes(dimension.note, dimension.extension?.noteMandatory),
+      valueDisplayType: getValueDisplayType(dimension.extension),
     };
 
     return variable;
@@ -412,28 +410,6 @@ function getValueDisplayType(
     }
   }
   return 'value';
-}
-
-/**
- * Returns the label text for a value based on the value display type.
- *
- * @param valueDisplayType - The value display type for the dimension.
- * @param code - The code of the value.
- * @param label - The label of the value.
- * @returns The label text for the value.
- */
-function getLabelText(
-  valueDisplayType: ValueDisplayType,
-  code: string,
-  label: string,
-): string {
-  if (valueDisplayType === 'code') {
-    return code;
-  } else if (valueDisplayType === 'value') {
-    return label;
-  } else {
-    return `${code} ${label}`;
-  }
 }
 
 /**


### PR DESCRIPTION
Since we want the ability to change codelists, we need to update the function that parses the new codelist metadata for a variable to properly handle the ValueDisplayType and value label texts. This adds similar parsing as the Json2Mapper.

Small refactor to extract shared functionality. If we decide to redo/change how we get the metadata when changing codelists, some of this might have to be redone/undone again.