### PR TITLE
Show status in datacells if provided

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Table/Table.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Table/Table.tsx
@@ -657,11 +657,13 @@ function fillData(
 
     tableRow.push(
       <td key={getNewKey()} headers={headers}>
-        {t(decimalFormats[numberOfDecimals] || 'number.simple_number', {
-          value: dataValue ?? '',
-        })}
+        {dataValue?.status ??
+          t(decimalFormats[numberOfDecimals] || 'number.simple_number', {
+            value: dataValue?.value ?? '',
+          })}
       </td>,
     ); // TODO: Handle null values
+    console.log('status i=', dataValue?.status);
   }
 }
 /**

--- a/packages/pxweb2-ui/src/lib/components/Table/Table.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Table/Table.tsx
@@ -653,17 +653,21 @@ function fillData(
       table.metadata.decimals ??
       6;
 
+    console.log('table.data.cube:', table.data.cube);
     const dataValue = getPxTableData(table.data.cube, dimensions);
 
     tableRow.push(
       <td key={getNewKey()} headers={headers}>
-        {dataValue?.status ??
-          t(decimalFormats[numberOfDecimals] || 'number.simple_number', {
-            value: dataValue?.value ?? '',
-          })}
+        {dataValue?.value === null || dataValue?.value === undefined
+          ? ''
+          : t(decimalFormats[numberOfDecimals] || 'number.simple_number', {
+              value: dataValue.value,
+            })}
+        {dataValue?.status ?? ''}
       </td>,
     ); // TODO: Handle null values
-    console.log('status i=', dataValue?.status);
+    console.log('status i table=', dataValue?.status);
+    console.log('value i table=', dataValue?.value);
   }
 }
 /**

--- a/packages/pxweb2-ui/src/lib/components/Table/Table.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Table/Table.tsx
@@ -653,7 +653,6 @@ function fillData(
       table.metadata.decimals ??
       6;
 
-    console.log('table.data.cube:', table.data.cube);
     const dataValue = getPxTableData(table.data.cube, dimensions);
 
     tableRow.push(
@@ -665,9 +664,7 @@ function fillData(
             })}
         {dataValue?.status ?? ''}
       </td>,
-    ); // TODO: Handle null values
-    console.log('status i table=', dataValue?.status);
-    console.log('value i table=', dataValue?.value);
+    );
   }
 }
 /**

--- a/packages/pxweb2-ui/src/lib/components/Table/cubeHelper.ts
+++ b/packages/pxweb2-ui/src/lib/components/Table/cubeHelper.ts
@@ -1,5 +1,5 @@
 import { PxTable } from '../../shared-types/pxTable';
-import { PxData } from '../../shared-types/pxTableData';
+import { DataCell, PxData } from '../../shared-types/pxTableData';
 
 /**
  * Represents an array of dimensions - one per variable in the table.
@@ -93,7 +93,11 @@ let number = 0;
  *
  * @returns The next sequential number.
  */
-function getNumber(): number {
-  number = number + 1;
-  return number;
+function getNumber(): DataCell {
+  const dataCell: DataCell = {
+    value: number,
+    status: '',
+    presentation: 'number',
+  };
+  return dataCell;
 }

--- a/packages/pxweb2-ui/src/lib/components/Table/cubeHelper.ts
+++ b/packages/pxweb2-ui/src/lib/components/Table/cubeHelper.ts
@@ -94,6 +94,7 @@ let number = 0;
  * @returns The next sequential number.
  */
 function getNumber(): DataCell {
+  number = number + 1;
   const dataCell: DataCell = {
     value: number,
     status: '',

--- a/packages/pxweb2-ui/src/lib/shared-types/pxTableData.ts
+++ b/packages/pxweb2-ui/src/lib/shared-types/pxTableData.ts
@@ -46,7 +46,7 @@ export type PxData<T> = {
 };
 
 export type DataCell = {
-  value: number;
+  value: number | null;
   status?: string;
   presentation?: 'number' | 'sign' | 'both';
 };

--- a/packages/pxweb2-ui/src/lib/shared-types/pxTableData.ts
+++ b/packages/pxweb2-ui/src/lib/shared-types/pxTableData.ts
@@ -5,7 +5,7 @@ export type PxTableData = {
   /**
    * The cube data containing the values for each cell in the table.
    */
-  cube: PxData<number>; // TODO: Maybe change number to a type DataCell with properties Value (number) and Status (string to handle ..)
+  cube: PxData<DataCell>; // TODO: Maybe change number to a type DataCell with properties Value (number) and Status (string to handle ..)
 
   /**
    * The order of the variables in the table data.
@@ -43,4 +43,10 @@ export type PxTableData = {
  *} */
 export type PxData<T> = {
   [key: string]: PxData<T> | T;
+};
+
+export type DataCell = {
+  value: number;
+  status?: string;
+  presentation?: 'number' | 'sign' | 'both';
 };

--- a/packages/pxweb2-ui/src/lib/shared-types/pxTableData.ts
+++ b/packages/pxweb2-ui/src/lib/shared-types/pxTableData.ts
@@ -5,7 +5,7 @@ export type PxTableData = {
   /**
    * The cube data containing the values for each cell in the table.
    */
-  cube: PxData<DataCell>; // TODO: Maybe change number to a type DataCell with properties Value (number) and Status (string to handle ..)
+  cube: PxData<DataCell>;
 
   /**
    * The order of the variables in the table data.

--- a/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
+++ b/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
@@ -23,7 +23,6 @@ import {
   DataCell,
 } from '@pxweb2/pxweb2-ui';
 import { getLabelText } from '../app/util/utils';
-import { n } from 'react-router/dist/development/fog-of-war-BLArG-qZ';
 
 /**
  * Internal type. Used to keep track of index in json-stat2 value array

--- a/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
+++ b/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
@@ -494,20 +494,20 @@ function CreateData(jsonData: Dataset, metadata: PxTableMetadata): PxTableData {
   // Create data cube
   const startTime = performance.now();
 
-  function createDataAndStatus(jsonData: Dataset): Record<string, DataCell> {
-    const dataAndStatus: Record<string, DataCell> = {};
+  //  function createDataAndStatus(jsonData: Dataset): Record<string, DataCell> {
+  //     const dataAndStatus: Record<string, DataCell> = {};
 
-    jsonData.value?.map((value, index) => {
-      dataAndStatus[index] = {
-        value: value,
-        status: jsonData.status ? jsonData.status[index] : undefined,
-        presentation: undefined,
-      };
-    });
-    console.log('dataAndStatus', dataAndStatus);
+  //     jsonData.value?.map((value, index) => {
+  //       dataAndStatus[index] = {
+  //         value: value,
+  //         status: jsonData.status ? jsonData.status[index] : undefined,
+  //         presentation: undefined,
+  //       };
+  //     });
+  //     console.log('dataAndStatus', dataAndStatus);
 
-    return dataAndStatus;
-  }
+  //     return dataAndStatus;
+  //   }
 
   const dataAndStatus = createDataAndStatus(jsonData);
 
@@ -522,6 +522,22 @@ function CreateData(jsonData: Dataset, metadata: PxTableMetadata): PxTableData {
   return data;
 }
 
+export function createDataAndStatus(
+  jsonData: Dataset,
+): Record<string, DataCell> {
+  const dataAndStatus: Record<string, DataCell> = {};
+
+  jsonData.value?.map((value, index) => {
+    dataAndStatus[index] = {
+      value: value,
+      status: jsonData.status ? jsonData.status[index] : undefined,
+      presentation: undefined,
+    };
+  });
+  console.log('dataAndStatus', dataAndStatus);
+
+  return dataAndStatus;
+}
 /**
  * Retrieves the data cell value from the JSON response based on the counter.
  * If no value array is present in the JSON response, it returns null.
@@ -554,7 +570,7 @@ function CreateData(jsonData: Dataset, metadata: PxTableMetadata): PxTableData {
  * @param counter - The counter object used to track the current index in the json-stat2 value array.
  */
 
-function createCube(
+export function createCube(
   valueAndStatus: Record<string, DataCell>,
   metadata: PxTableMetadata,
   data: PxTableData,

--- a/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
+++ b/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
@@ -20,8 +20,10 @@ import {
   Contact,
   ContentInfo,
   Note,
+  DataCell,
 } from '@pxweb2/pxweb2-ui';
 import { getLabelText } from '../app/util/utils';
+import { n } from 'react-router/dist/development/fog-of-war-BLArG-qZ';
 
 /**
  * Internal type. Used to keep track of index in json-stat2 value array
@@ -513,7 +515,12 @@ function getDataCellValue(jsonData: Dataset, counter: counter): number | null {
   }
   return jsonData.value?.[counter.number];
 }
-
+function getDataCellStatues(jsonData: Dataset): Record<string, string> | null {
+  if (jsonData.status === undefined || jsonData.status === null) {
+    return null;
+  }
+  return jsonData.status;
+}
 /**
  * Recursively creates a data cube for the PxTable based on the provided JSONStat2 dataset and metadata.
  *
@@ -532,14 +539,26 @@ function createCube(
   dimensionIndex: number,
   counter: counter,
 ): void {
+  const statusCodes = getDataCellStatues(jsonData);
   if (dimensionIndex === metadata.variables.length - 1) {
     metadata.variables[dimensionIndex].values.forEach((value) => {
+      const tempDatacell: DataCell = {
+        value: null,
+        status: undefined,
+        presentation: undefined,
+      };
       dimensions[dimensionIndex] = value.code;
-      setPxTableData(
-        data.cube,
-        dimensions,
-        getDataCellValue(jsonData, counter),
-      );
+      tempDatacell.value = getDataCellValue(jsonData, counter);
+
+      if (statusCodes) {
+        tempDatacell.status = statusCodes[counter.number] ?? undefined;
+        console.log(
+          'counter.number:' + counter.number,
+          'statusCodes[counter.number]:',
+          statusCodes[counter.number],
+        );
+      }
+      setPxTableData(data.cube, dimensions, tempDatacell);
       counter.number++;
     });
   } else {

--- a/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
+++ b/packages/pxweb2/src/mappers/JsonStat2ResponseMapper.ts
@@ -488,40 +488,25 @@ function CreateData(jsonData: Dataset, metadata: PxTableMetadata): PxTableData {
     isLoaded: false,
   };
 
+  const dataAndStatus = createDataAndStatus(jsonData);
+
   // Counter to keep track of index in json-stat2 value array
   const counter = { number: 0 };
 
   // Create data cube
-  const startTime = performance.now();
-
-  //  function createDataAndStatus(jsonData: Dataset): Record<string, DataCell> {
-  //     const dataAndStatus: Record<string, DataCell> = {};
-
-  //     jsonData.value?.map((value, index) => {
-  //       dataAndStatus[index] = {
-  //         value: value,
-  //         status: jsonData.status ? jsonData.status[index] : undefined,
-  //         presentation: undefined,
-  //       };
-  //     });
-  //     console.log('dataAndStatus', dataAndStatus);
-
-  //     return dataAndStatus;
-  //   }
-
-  const dataAndStatus = createDataAndStatus(jsonData);
-
-  //createCube(jsonData, metadata, data, [], 0, counter);
   createCube(dataAndStatus, metadata, data, [], 0, counter);
-  const endTime = performance.now();
-  console.log(`createCube execution time: ${endTime - startTime} ms`);
-
   data.variableOrder = jsonData.id; // Array containing the variable ids;
   data.isLoaded = true;
-
   return data;
 }
-
+/**
+ * Create a data and status object from the JSONStat2 dataset
+ * @param jsonData - The JSONStat2 dataset containing the data values.
+ * @returns A record where the keys are the indices and the values are DataCell objects.
+ * Each DataCell object contains the value, status, and presentation information.
+ * The status is optional and may be undefined if not present in the dataset.
+ * The presentation is also optional and may be undefined if not present in the dataset.
+ */
 export function createDataAndStatus(
   jsonData: Dataset,
 ): Record<string, DataCell> {
@@ -534,31 +519,9 @@ export function createDataAndStatus(
       presentation: undefined,
     };
   });
-  console.log('dataAndStatus', dataAndStatus);
-
   return dataAndStatus;
 }
-/**
- * Retrieves the data cell value from the JSON response based on the counter.
- * If no value array is present in the JSON response, it returns null.
- *
- * @param jsonData - The JSON-stat2 response containing the data values.
- * @param counter - The counter object used to track the current index in the json-stat2 value array.
- * @returns The data cell value or null if not found.
- */
-// function getDataCellValue(jsonData: Dataset, counter: counter): number | null {
-//   if (jsonData.value === undefined || jsonData.value === null) {
-//     return null;
-//   }
-//   return jsonData.value?.[counter.number];
-// }
-// function getDataCellStatues(jsonData: Dataset): Record<string, string> | null {
-//   console.log('jsonData.status', jsonData.status);
-//   if (jsonData.status === undefined || jsonData.status === null) {
-//     return null;
-//   }
-//   return jsonData.status;
-// }
+
 /**
  * Recursively creates a data cube for the PxTable based on the provided JSONStat2 dataset and metadata.
  *
@@ -584,7 +547,6 @@ export function createCube(
       const tempDatacell = valueAndStatus[counter.number];
       setPxTableData(data.cube, dimensions, tempDatacell);
       counter.number++;
-      console.log('valueAndStatus:', valueAndStatus);
     });
   } else {
     metadata.variables[dimensionIndex].values.forEach((value) => {


### PR DESCRIPTION
Datacells with numbers returned from API could have a status connected. If so the status should be shown together or instead of the number