### PR TITLE
Add language to url for language persistance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6633,6 +6633,15 @@
         }
       }
     },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.5.tgz",
+      "integrity": "sha512-OstebRKqKiQw8xEvQF5aRyUujsCatanj7Q9eo5iiH2gJpoXGZ7483ol3sVBwfqbobTQPNH1J+NAyJ1aCQoEC+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/i18next-http-backend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.2.tgz",
@@ -11272,6 +11281,7 @@
       "dependencies": {
         "@emotion/is-prop-valid": "^1.3.1",
         "@pxweb2/pxweb2-ui": "*",
+        "i18next-browser-languagedetector": "^8.0.5",
         "i18next-http-backend": "^3.0.2",
         "react-router": "^7.5.2"
       },

--- a/packages/pxweb2/package.json
+++ b/packages/pxweb2/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@emotion/is-prop-valid": "^1.3.1",
     "@pxweb2/pxweb2-ui": "*",
+    "i18next-browser-languagedetector": "^8.0.5",
     "i18next-http-backend": "^3.0.2",
     "react-router": "^7.5.2"
   },

--- a/packages/pxweb2/src/app/components/ErrorBoundry/ErrorBoundry.spec.tsx
+++ b/packages/pxweb2/src/app/components/ErrorBoundry/ErrorBoundry.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
+
 import ErrorBoundary from './ErrorBoundry';
 
 // Mock the Header component
@@ -17,6 +18,28 @@ vi.mock('@pxweb2/pxweb2-ui', () => ({
 }));
 
 describe('ErrorBoundary', () => {
+  // Setup console mocks before all tests
+  let consoleErrorSpy: any;
+  let consoleLogSpy: any;
+
+  beforeAll(() => {
+    // Suppress React error logging and component console.log
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    // Restore console mocks
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    // Clear mock history between tests
+    consoleErrorSpy.mockClear();
+    consoleLogSpy.mockClear();
+  });
+
   it('renders children when no error occurs', () => {
     render(
       <ErrorBoundary>
@@ -29,11 +52,6 @@ describe('ErrorBoundary', () => {
   });
 
   it('renders fallback UI when an error occurs', () => {
-    // Suppress React error logging
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-
     // Create a component that throws an error
     const ErrorComponent = () => {
       throw new Error('Test error');
@@ -49,15 +67,9 @@ describe('ErrorBoundary', () => {
     // Assert that the fallback UI is rendered
     expect(screen.getByRole('banner')).toBeInTheDocument(); // Header
     expect(screen.getByRole('alert')).toHaveTextContent('Test error'); // Alert with error message
-
-    // Restore the console.error mock
-    consoleErrorSpy.mockRestore();
   });
 
   it('logs the error to the console', () => {
-    // Spy on console.log
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
     // Create a component that throws an error
     const ErrorComponent = () => {
       throw new Error('Test error');
@@ -71,12 +83,9 @@ describe('ErrorBoundary', () => {
     );
 
     // Assert that the error was logged
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({ componentStack: expect.any(String) }),
     );
-
-    // Restore the console.log mock
-    consoleSpy.mockRestore();
   });
 });

--- a/packages/pxweb2/src/app/components/ErrorPage/ErrorPage.spec.tsx
+++ b/packages/pxweb2/src/app/components/ErrorPage/ErrorPage.spec.tsx
@@ -1,40 +1,53 @@
-import { vi } from 'vitest';
+import { vi, Mock } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { useRouteError, useLocation } from 'react-router';
 
 import { ErrorPage } from './ErrorPage';
+import { getConfig } from '../../util/config/getConfig';
 import { renderWithProviders } from '../../util/testing-utils';
 
-// Mock React Router - only need to mock this once
+vi.mock('../../util/config/getConfig');
 vi.mock('react-router', () => ({
-  MemoryRouter: vi.fn().mockImplementation(({ children }) => children),
-  useRouteError: vi.fn().mockReturnValue({
+  useRouteError: vi.fn(),
+  useLocation: vi.fn(),
+  Link: vi.fn(({ to, children, ...props }) => (
+    <a href={to.pathname} {...props}>
+      {children}
+    </a>
+  )),
+}));
+
+describe('ErrorPage', () => {
+  const mockError = {
     status: 404,
     statusText: 'Not Found',
     message: 'The requested resource was not found.',
     data: 'Additional error data',
-  }),
-  useLocation: vi.fn().mockReturnValue({
+  };
+  const mockLocation = {
     pathname: '/en/table/tab638',
     search: '',
     hash: '',
     state: null,
     key: 'default',
-  }),
-  Link: vi.fn(({ to, children }) => <a href={to}>{children}</a>),
-}));
-
-vi.mock('../../util/config/getConfig', () => ({
-  getConfig: vi.fn(() => ({
+  };
+  const mockConfig = {
     language: {
       supportedLanguages: [
         { shorthand: 'en', languageName: 'English' },
         { shorthand: 'no', languageName: 'Norwegian' },
       ],
     },
-  })),
-}));
+  };
 
-describe('ErrorPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Default mocks
+    (useRouteError as Mock).mockReturnValue(mockError);
+    (useLocation as Mock).mockReturnValue(mockLocation);
+    (getConfig as Mock).mockReturnValue(mockConfig);
+  });
   it('renders without crashing', () => {
     const { baseElement } = renderWithProviders(<ErrorPage />);
 

--- a/packages/pxweb2/src/app/components/ErrorPage/ErrorPage.tsx
+++ b/packages/pxweb2/src/app/components/ErrorPage/ErrorPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Alert } from '@pxweb2/pxweb2-ui';
 import { useRouteError } from 'react-router';
+import React from 'react';
+
+import { Alert } from '@pxweb2/pxweb2-ui';
 import { Header } from '../Header/Header';
 
 // ErrorPage component to display error messages
@@ -11,8 +12,10 @@ type RouteError = {
   data?: string;
 };
 
+// This component is used to display error messages when a route error occurs
+// It will therefore always have a route error
 export const ErrorPage: React.FC = () => {
-  const error = useRouteError() as RouteError | null;
+  const error = useRouteError() as RouteError;
 
   return (
     <>

--- a/packages/pxweb2/src/app/components/Header/Header.tsx
+++ b/packages/pxweb2/src/app/components/Header/Header.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import cl from 'clsx';
 
 import styles from './Header.module.scss';
-import { Button } from '@pxweb2/pxweb2-ui';
-import { getConfig } from '../../util/config/getConfig';
 import { useTranslation } from 'react-i18next';
+import { LanguageSwitcher } from '../LanguageSwitcher/LanguageSwitcher';
 export const Header: React.FC = () => {
-  const { t, i18n } = useTranslation();
-  const config = getConfig();
+  const { t } = useTranslation();
 
   return (
     <header className={styles.header}>
@@ -16,20 +14,7 @@ export const Header: React.FC = () => {
           {t('common.header.title')}
         </span>
       </div>
-      <div>
-        {config.language.supportedLanguages.map(
-          (language) =>
-            i18n.language !== language.shorthand && (
-              <Button
-                variant="tertiary"
-                onClick={() => i18n.changeLanguage(language.shorthand)}
-                key={language.shorthand}
-              >
-                {language.languageName}
-              </Button>
-            ),
-        )}
-      </div>
+      <LanguageSwitcher />
     </header>
   );
 };

--- a/packages/pxweb2/src/app/components/LanguageSwitcher/LanguageSwitcher.spec.tsx
+++ b/packages/pxweb2/src/app/components/LanguageSwitcher/LanguageSwitcher.spec.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
+import '@testing-library/jest-dom/vitest';
+
+import { LanguageSwitcher } from './LanguageSwitcher';
+import { getConfig } from '../../util/config/getConfig';
+import { getLanguagePath } from '../../util/language/getLanguagePath';
+
+// Mock dependencies
+vi.mock('../../util/config/getConfig');
+vi.mock('../../util/language/getLanguagePath');
+vi.mock('react-i18next', () => ({
+  useTranslation: vi.fn(),
+}));
+vi.mock('react-router', () => ({
+  useLocation: vi.fn(),
+  Link: vi.fn(({ to, children, ...props }) => (
+    <a href={to.pathname} {...props}>
+      {children}
+    </a>
+  )),
+}));
+
+describe('LanguageSwitcher', () => {
+  const mockChangeLanguage = vi.fn();
+  const mockLocation = { pathname: '/test/path' };
+  const mockConfig = {
+    language: {
+      supportedLanguages: [
+        { languageName: 'English', shorthand: 'en' },
+        { languageName: 'Norwegian', shorthand: 'no' },
+        { languageName: 'Swedish', shorthand: 'sv' },
+      ],
+      fallbackLanguage: 'en',
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Default mocks
+    (getConfig as Mock).mockReturnValue(mockConfig);
+    (useLocation as Mock).mockReturnValue(mockLocation);
+    (getLanguagePath as Mock).mockImplementation((path, lang) =>
+      lang === 'en' ? path : `/${lang}${path}`,
+    );
+    (useTranslation as Mock).mockReturnValue({
+      i18n: {
+        language: 'en',
+        changeLanguage: mockChangeLanguage,
+      },
+    });
+  });
+
+  it('renders language buttons for all supported languages except current language', () => {
+    render(<LanguageSwitcher />);
+
+    // Check that all supported languages are rendered except the current one
+    expect(screen.queryByText('English')).not.toBeInTheDocument();
+    expect(screen.getByText('Norwegian')).toBeInTheDocument();
+    expect(screen.getByText('Swedish')).toBeInTheDocument();
+  });
+
+  it('generates correct paths for language links', () => {
+    render(<LanguageSwitcher />);
+
+    const norwegianLink = screen.getByText('Norwegian').closest('a');
+    const swedishLink = screen.getByText('Swedish').closest('a');
+
+    // Check that the getLanguagePath function was called with the correct arguments
+    expect(getLanguagePath).toHaveBeenCalledWith(
+      '/test/path',
+      'no',
+      mockConfig.language.supportedLanguages,
+      mockConfig.language.fallbackLanguage,
+    );
+    expect(getLanguagePath).toHaveBeenCalledWith(
+      '/test/path',
+      'sv',
+      mockConfig.language.supportedLanguages,
+      mockConfig.language.fallbackLanguage,
+    );
+
+    // Check that the getLanguagePath function was called twice (once for each language except the current one)
+    expect(getLanguagePath).toHaveBeenCalledTimes(2);
+
+    // We're using a simple mock that just prefixes the path with language code
+    expect(norwegianLink).toHaveAttribute('href', '/no/test/path');
+    expect(swedishLink).toHaveAttribute('href', '/sv/test/path');
+  });
+
+  it('triggers language change when a button is clicked', async () => {
+    render(<LanguageSwitcher />);
+    const user = userEvent.setup();
+    const norwegianButton = screen.getByText('Norwegian');
+
+    await user.click(norwegianButton);
+
+    expect(mockChangeLanguage).toHaveBeenCalledWith('no');
+  });
+
+  it('shows different language options when current language changes', () => {
+    (useTranslation as Mock).mockReturnValue({
+      i18n: {
+        language: 'no',
+        changeLanguage: mockChangeLanguage,
+      },
+    });
+
+    render(<LanguageSwitcher />);
+
+    // Don't show the current language
+    expect(screen.queryByText('Norwegian')).not.toBeInTheDocument();
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.getByText('Swedish')).toBeInTheDocument();
+  });
+});

--- a/packages/pxweb2/src/app/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/pxweb2/src/app/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -3,20 +3,12 @@ import { useTranslation } from 'react-i18next';
 
 import { Button } from '@pxweb2/pxweb2-ui';
 import { getConfig } from '../../util/config/getConfig';
+import { getLanguagePath } from '../../util/language/getLanguagePath';
 
 export const LanguageSwitcher = () => {
   const { i18n } = useTranslation();
   const config = getConfig();
   const location = useLocation();
-
-  const [firstURLElement, ...pathParts] = location.pathname.slice(1).split('/');
-  const isLanguagePath = config.language.supportedLanguages.some(
-    (lang) => lang.shorthand === firstURLElement,
-  );
-
-  const actualPath = isLanguagePath
-    ? pathParts.join('/')
-    : [firstURLElement, ...pathParts].join('/');
 
   return (
     <div>
@@ -26,10 +18,12 @@ export const LanguageSwitcher = () => {
           i18n.language !== language.shorthand && (
             <LinkRouter
               to={{
-                pathname:
-                  language.shorthand === config.language.fallbackLanguage
-                    ? `/${actualPath}`
-                    : `/${language.shorthand}/${actualPath}`,
+                pathname: getLanguagePath(
+                  location.pathname,
+                  language.shorthand,
+                  config.language.supportedLanguages,
+                  config.language.fallbackLanguage,
+                ),
               }}
               key={language.shorthand}
             >

--- a/packages/pxweb2/src/app/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/pxweb2/src/app/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,0 +1,47 @@
+import { Link as LinkRouter, useLocation } from 'react-router';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@pxweb2/pxweb2-ui';
+import { getConfig } from '../../util/config/getConfig';
+
+export const LanguageSwitcher = () => {
+  const { i18n } = useTranslation();
+  const config = getConfig();
+  const location = useLocation();
+
+  const [firstURLElement, ...pathParts] = location.pathname.slice(1).split('/');
+  const isLanguagePath = config.language.supportedLanguages.some(
+    (lang) => lang.shorthand === firstURLElement,
+  );
+
+  const actualPath = isLanguagePath
+    ? pathParts.join('/')
+    : [firstURLElement, ...pathParts].join('/');
+
+  return (
+    <div>
+      {config.language.supportedLanguages.map(
+        (language) =>
+          // Don't show the current language
+          i18n.language !== language.shorthand && (
+            <LinkRouter
+              to={{
+                pathname:
+                  language.shorthand === config.language.fallbackLanguage
+                    ? `/${actualPath}`
+                    : `/${language.shorthand}/${actualPath}`,
+              }}
+              key={language.shorthand}
+            >
+              <Button
+                variant="tertiary"
+                onClick={() => i18n.changeLanguage(language.shorthand)}
+              >
+                {language.languageName}
+              </Button>
+            </LinkRouter>
+          ),
+      )}
+    </div>
+  );
+};

--- a/packages/pxweb2/src/app/components/Selection/Selection.tsx
+++ b/packages/pxweb2/src/app/components/Selection/Selection.tsx
@@ -267,7 +267,7 @@ type propsType = {
     close: boolean,
     view: NavigationItem,
   ) => void;
-  hideMenuRef?: React.RefObject<HTMLDivElement>;
+  hideMenuRef?: React.RefObject<HTMLDivElement | null>;
 };
 
 export function Selection({

--- a/packages/pxweb2/src/app/util/language/getLanguagePath.spec.tsx
+++ b/packages/pxweb2/src/app/util/language/getLanguagePath.spec.tsx
@@ -1,0 +1,94 @@
+import { getLanguagePath } from './getLanguagePath';
+
+describe('getLanguagePath', () => {
+  const supportedLanguages = [
+    { languageName: 'Norwegian', shorthand: 'no' },
+    { languageName: 'English', shorthand: 'en' },
+    { languageName: 'Polish', shorthand: 'pl' },
+  ];
+  const fallbackLanguage = 'en';
+
+  it('should return the correct path when pathname starts with a language code and target is fallback', () => {
+    const pathname = '/no/some/path';
+    const targetLanguage = 'en';
+
+    const result = getLanguagePath(
+      pathname,
+      targetLanguage,
+      supportedLanguages,
+      fallbackLanguage,
+    );
+
+    expect(result).toBe('/some/path');
+  });
+
+  it('should return the correct path when pathname starts with a language code and target is not fallback', () => {
+    const pathname = '/en/some/path';
+    const targetLanguage = 'no';
+
+    const result = getLanguagePath(
+      pathname,
+      targetLanguage,
+      supportedLanguages,
+      fallbackLanguage,
+    );
+
+    expect(result).toBe('/no/some/path');
+  });
+
+  it('should return the correct path when pathname does not start with a language code and target is fallback', () => {
+    const pathname = '/some/path';
+    const targetLanguage = 'en';
+
+    const result = getLanguagePath(
+      pathname,
+      targetLanguage,
+      supportedLanguages,
+      fallbackLanguage,
+    );
+
+    expect(result).toBe('/some/path');
+  });
+
+  it('should return the correct path when pathname does not start with a language code and target is not fallback', () => {
+    const pathname = '/some/path';
+    const targetLanguage = 'no';
+
+    const result = getLanguagePath(
+      pathname,
+      targetLanguage,
+      supportedLanguages,
+      fallbackLanguage,
+    );
+
+    expect(result).toBe('/no/some/path');
+  });
+
+  it('should handle empty path correctly', () => {
+    const pathname = '/';
+    const targetLanguage = 'no';
+
+    const result = getLanguagePath(
+      pathname,
+      targetLanguage,
+      supportedLanguages,
+      fallbackLanguage,
+    );
+
+    expect(result).toBe('/no/');
+  });
+
+  it('should handle path with only language code correctly', () => {
+    const pathname = '/no';
+    const targetLanguage = 'pl';
+
+    const result = getLanguagePath(
+      pathname,
+      targetLanguage,
+      supportedLanguages,
+      fallbackLanguage,
+    );
+
+    expect(result).toBe('/pl/');
+  });
+});

--- a/packages/pxweb2/src/app/util/language/getLanguagePath.ts
+++ b/packages/pxweb2/src/app/util/language/getLanguagePath.ts
@@ -1,0 +1,29 @@
+import { Config as LanguageConfig } from '../../util/config/configType';
+
+/**
+ * Extracts the actual path without language prefix and generates the correct path for the target language
+ * @param pathname Current pathname from location
+ * @param targetLanguage The language to switch to
+ * @param supportedLanguages List of supported languages
+ * @param fallbackLanguage The fallback language code
+ * @returns The correct path for the target language
+ */
+export const getLanguagePath = (
+  pathname: string,
+  targetLanguage: string,
+  supportedLanguages: LanguageConfig['language']['supportedLanguages'],
+  fallbackLanguage: string,
+): string => {
+  const [firstURLElement, ...pathParts] = pathname.slice(1).split('/');
+  const isLanguagePath = supportedLanguages.some(
+    (lang) => lang.shorthand === firstURLElement,
+  );
+
+  const actualPath = isLanguagePath
+    ? pathParts.join('/')
+    : [firstURLElement, ...pathParts].join('/');
+
+  return targetLanguage === fallbackLanguage
+    ? `/${actualPath}`
+    : `/${targetLanguage}/${actualPath}`;
+};

--- a/packages/pxweb2/src/i18n/config.ts
+++ b/packages/pxweb2/src/i18n/config.ts
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
-import HttpApi from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
+import HttpApi from 'i18next-http-backend';
+import LanguageDetector from 'i18next-browser-languagedetector';
 
 import { pxNumber } from './formatters';
 import { getConfig } from '../app/util/config/getConfig';
@@ -15,6 +16,7 @@ const supportedLanguages: string[] = config.language.supportedLanguages.map(
 i18n
   .use(HttpApi)
   .use(initReactI18next)
+  .use(LanguageDetector)
   .init({
     backend: {
       requestOptions: {
@@ -23,15 +25,17 @@ i18n
         cache: 'no-store',
       },
     },
-    lng: config.language.defaultLanguage,
     fallbackLng: config.language.fallbackLanguage,
     defaultNS,
-    // Explicitly tell i18next our
-    // supported locales.
+    // Explicitly tell i18next our supported locales.
     supportedLngs: supportedLanguages,
     debug: true,
     interpolation: {
       escapeValue: false,
+    },
+    detection: {
+      order: ['path'],
+      caches: [], // Do not cache the language in local storage or cookies.
     },
   });
 

--- a/packages/pxweb2/src/main.tsx
+++ b/packages/pxweb2/src/main.tsx
@@ -11,19 +11,20 @@ import ErrorPage from './app/components/ErrorPage/ErrorPage';
 
 const router = createBrowserRouter([
   {
-    path: '/table',
-    element: <Navigate to="/table/tab638" replace={true} />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: '/',
-    element: <StartPage />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: '/table/:tableId',
-    element: <TableViewer />,
-    errorElement: <ErrorPage />,
+    path: '/:lang?',
+    children: [
+      { index: true, element: <StartPage />, errorElement: <ErrorPage /> },
+      {
+        path: 'table',
+        element: <Navigate to="/table/tab638" replace={true} />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'table/:tableId',
+        element: <TableViewer />,
+        errorElement: <ErrorPage />,
+      },
+    ],
   },
 ]);
 

--- a/packages/pxweb2/test/setupTests.ts
+++ b/packages/pxweb2/test/setupTests.ts
@@ -6,6 +6,7 @@ vi.mock('react-i18next', () => ({
     i18n: {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       changeLanguage: () => new Promise(() => {}),
+      language: 'en',
       dir: () => 'ltr',
     },
   }),


### PR DESCRIPTION
Since we need to support several languages in the project, we need to add language persistence. What complicates this is that a table can be available in only one language, even though several can be supported for the entire site. And we also need it to work when people share links with other people.

This adds an optional language part to the url, and it uses the fallback language if that part is missing. This means that urls like '/sv/table/tableid' and '/table/tableid' both will work. Since it seems unlikely a site will change its default/fallback language.

I installed the i18next package for detecting browser languages, but set it up to only check for path, and to not cache the values. Since we only want the language in the URL to matter, and to avoid any situations where a user has an invalid language selected for the site, for the table they are trying to view.

Added tests, and also had to refactor some for the ErrorPage and ErrorBoundry. This work on the tests was done in large part with Claude 3.7.