### PR TITLE
Fixed bug when checking if there are any changes in selected variables and values

### DIFF
--- a/packages/pxweb2/src/app/context/VariablesProvider.tsx
+++ b/packages/pxweb2/src/app/context/VariablesProvider.tsx
@@ -160,6 +160,8 @@ export const VariablesProvider: React.FC<{ children: React.ReactNode }> = ({
    * @returns
    */
   const hasChanges = (newVariables: SelectedVBValues[]) => {
+    let selectionHasChanges = false;
+
     const newVars: Set<string> = new Set();
     newVariables.forEach((variable) => {
       variable.values.forEach((value) => {
@@ -176,17 +178,23 @@ export const VariablesProvider: React.FC<{ children: React.ReactNode }> = ({
     // If it is missing, that means there has been some changes
     variables.forEach((variable, key) => {
       if (!newVars.has(key)) {
-        return true;
+        selectionHasChanges = true;
       }
     });
+    if (selectionHasChanges) {
+      return true;
+    }
 
     // Check if newVars has some key that is missing in variables.
     // If it is missing, that means there has been some changes
     newVars.forEach((val) => {
       if (!variables.has(val)) {
-        return true;
+        selectionHasChanges = true;
       }
     });
+    if (selectionHasChanges) {
+      return true;
+    }
 
     // No changes found
     return false;


### PR DESCRIPTION
In some cases changes in selected variables and was not detected.
There was a bug in the hasChanges function in the VariablesProvider. Instead of returning true from the function when there was a change in selection, the code just returned from the forEach-loop within the function. This is now fixed.