### PR TITLE
Fix for missing id in aria-labelledby attribute

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxHeader/VariableBoxHeader.tsx
@@ -95,7 +95,13 @@ export function VariableBoxHeader({
         <button
           className={cl(classes['variablebox-header-button']) + cssClasses}
           aria-expanded={isOpen}
-          aria-labelledby={titleId + ' ' + tagsId + ' ' + alertId}
+          aria-labelledby={
+            titleId +
+            ' ' +
+            tagsId +
+            ' ' +
+            (isMissingMandatoryValues ? alertId : '')
+          }
         >
           {isOpen ? (
             <Icon iconName="ChevronUp"></Icon>


### PR DESCRIPTION
Id for alert is only included if alert is present.