### PR TITLE
Add ContentBox component

### DIFF
--- a/packages/pxweb2-ui/package.json
+++ b/packages/pxweb2-ui/package.json
@@ -9,6 +9,7 @@
     "build-style-dictionary": "node ./style-dictionary/build.mjs",
     "storybook": "storybook dev -p 6006",
     "test": "vitest run",
+    "test-dev": "vitest",
     "coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "prettier": "prettier --config ../../.prettierrc --check ./src/** --write --ignore-path ../../.prettierignore"

--- a/packages/pxweb2-ui/src/index.ts
+++ b/packages/pxweb2-ui/src/index.ts
@@ -6,7 +6,7 @@ export * from './lib/components/Button/Button';
 export * from './lib/components/Checkbox/Checkbox';
 export * from './lib/components/Chips/Chips';
 export * from './lib/components/Contact/Contact';
-export * from './lib/components/Contact/Contact';
+export * from './lib/components/ContentBox/ContentBox';
 export * from './lib/components/EmptyState/EmptyState';
 export * from './lib/components/FilterCategory/FilterCategory';
 export * from './lib/components/Icon/Icon';

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.module.scss
@@ -5,12 +5,12 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 1rem;
   width: 100%;
-  padding: 1.5rem;
+  padding: 0.75rem;
 
   border-radius: var(--px-border-radius-large);
-  background: var(--px-color-surface-default) !important;
+  background: var(--px-color-surface-default);
 }
 
 .title {
@@ -19,8 +19,4 @@
   flex-direction: column;
   align-items: flex-start;
   align-self: stretch;
-}
-
-.titleText {
-  color: var(--px-color-text-default);
 }

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.module.scss
@@ -1,0 +1,26 @@
+@use '../../text-styles.scss';
+
+.contentBox {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 1.5rem;
+
+  border-radius: var(--px-border-radius-large);
+  background: var(--px-color-surface-default) !important;
+}
+
+.title {
+  display: flex;
+  padding: 0.5rem 0.5rem 0px 0.5rem;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+}
+
+.titleText {
+  color: var(--px-color-text-default);
+}

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.spec.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, getByText } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { ContentBox } from './ContentBox';
+
+describe('ContentBox', () => {
+  it('renders children correctly', () => {
+    const { container } = render(
+      <ContentBox>
+        <p>Hello World</p>
+      </ContentBox>,
+    );
+
+    expect(getByText(container, 'Hello World')).toBeInTheDocument();
+  });
+
+  describe('title', () => {
+    it('renders when provided', () => {
+      const { container } = render(
+        <ContentBox title="Test Title">
+          <p>Content</p>
+        </ContentBox>,
+      );
+
+      expect(getByText(container, 'Test Title')).toBeInTheDocument();
+    });
+
+    it('does not render when not provided', () => {
+      const { container } = render(
+        <ContentBox>
+          <p>Content without title</p>
+        </ContentBox>,
+      );
+
+      expect(container.querySelector('h3')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ContentBox } from './ContentBox';
+
+const meta: Meta<typeof ContentBox> = {
+  component: ContentBox,
+  title: 'Components/ContentBox',
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          padding: '3em',
+          backgroundColor: 'var(--px-color-background-subtle)',
+        }}
+      >
+        {/* 👇 Decorators in Storybook also accept a function. Replace <Story/> with Story() to enable it  */}
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContentBox>;
+
+export const withTitle: Story = {
+  name: 'With title',
+  args: {
+    title: 'Edit',
+    children: <>Children goes here</>,
+  },
+};
+
+export const withoutTitle: Story = {
+  name: 'Without title',
+  args: {
+    children: <>Children goes here</>,
+  },
+};
+
+export const withLongContent: Story = {
+  name: 'With long content',
+  args: {
+    title: 'Long Content Example',
+    children: (
+      <>
+        <>Children goes here</>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+      </>
+    ),
+  },
+};

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.stories.tsx
@@ -27,14 +27,14 @@ export const withTitle: Story = {
   name: 'With title',
   args: {
     title: 'Edit',
-    children: <>Children goes here</>,
+    children: <span>Children goes here</span>,
   },
 };
 
 export const withoutTitle: Story = {
   name: 'Without title',
   args: {
-    children: <>Children goes here</>,
+    children: <span>Children goes here</span>,
   },
 };
 
@@ -44,7 +44,7 @@ export const withLongContent: Story = {
     title: 'Long Content Example',
     children: (
       <>
-        <>Children goes here</>
+        <span>Children goes here</span>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
@@ -4,8 +4,8 @@ import cl from 'clsx';
 import styles from './ContentBox.module.scss';
 
 interface ContentBoxProps {
-  title?: string;
-  children: ReactNode;
+  readonly title?: string;
+  readonly children: ReactNode;
 }
 
 export function ContentBox({ title, children }: ContentBoxProps) {

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import cl from 'clsx';
 
 import styles from './ContentBox.module.scss';
+import Heading from '../Typography/Heading/Heading';
 
 interface ContentBoxProps {
   readonly title?: string;
@@ -13,9 +14,9 @@ export function ContentBox({ title, children }: ContentBoxProps) {
     <div className={cl(styles.contentBox)}>
       {title && (
         <div className={cl(styles.title)}>
-          <h3 className={cl(styles.titleText, styles[`label-small`])}>
+          <Heading level={'3'} size={'small'}>
             {title}
-          </h3>
+          </Heading>
         </div>
       )}
       {children}

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+import cl from 'clsx';
+
+import styles from './ContentBox.module.scss';
+
+interface ContentBoxProps {
+  title?: string;
+  children: ReactNode;
+}
+
+export function ContentBox({ title, children }: ContentBoxProps) {
+  return (
+    <div className={cl(styles.contentBox)}>
+      {title && (
+        <div className={cl(styles.title)}>
+          <h3 className={cl(styles.titleText, styles[`label-small`])}>
+            {title}
+          </h3>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+ContentBox.displayName = 'ContentBox';

--- a/packages/pxweb2-ui/src/lib/components/VariableList/VariableList.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/VariableList/VariableList.module.scss
@@ -1,7 +1,7 @@
 @use '../../../../style-dictionary/dist/scss/fixed-variables.scss' as fixed;
 
 .variableList {
-  width: auto;
+  width: 100%;
   height: auto;
   display: flex;
   flex-direction: column;

--- a/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.module.scss
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.module.scss
@@ -135,11 +135,6 @@
   }
 }
 
-// Not from Figma
-.children {
-  width: 100%;
-}
-
 .fadein {
   animation: fadeIn 200ms forwards;
 }

--- a/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/NavigationDrawer.tsx
@@ -99,7 +99,7 @@ export const NavigationDrawer = forwardRef<
             </Label>
           </div>
         </div>
-        <div className={styles.children}>{children}</div>
+        {children}
       </div>
     </>
   );

--- a/packages/pxweb2/src/app/components/Selection/Selection.tsx
+++ b/packages/pxweb2/src/app/components/Selection/Selection.tsx
@@ -5,16 +5,17 @@ import { ApiError, TableService } from '@pxweb2/pxweb2-api-client';
 import { mapJsonStat2Response } from '../../../mappers/JsonStat2ResponseMapper';
 import { mapTableSelectionResponse } from '../../../mappers/TableSelectionResponseMapper';
 import {
-  PxTableMetadata,
-  SelectedVBValues,
-  VariableList,
-  Value,
-  SelectOption,
-  mapCodeListToSelectOption,
+  CodeList,
+  ContentBox,
   PxTable,
+  PxTableMetadata,
+  mapCodeListToSelectOption,
+  SelectedVBValues,
+  SelectOption,
+  Value,
   ValueDisplayType,
   Variable,
-  CodeList,
+  VariableList,
 } from '@pxweb2/pxweb2-ui';
 import NavigationDrawer from '../../components/NavigationDrawer/NavigationDrawer';
 import useVariables from '../../context/useVariables';
@@ -606,7 +607,14 @@ export function Selection({
   );
   const drawerView = <>View content</>;
   const drawerEdit = <>Edit content</>;
-  const drawerSave = <>Save content</>;
+  const drawerSave = (
+    <>
+      <ContentBox>This is inside a ContentBox</ContentBox>
+      <ContentBox title="Contentbox with title">
+        This is inside another with a title ContentBox
+      </ContentBox>
+    </>
+  );
   const drawerHelp = <>Help content</>;
 
   return (

--- a/packages/pxweb2/src/app/components/Selection/Selection.tsx
+++ b/packages/pxweb2/src/app/components/Selection/Selection.tsx
@@ -609,10 +609,10 @@ export function Selection({
   const drawerEdit = <>Edit content</>;
   const drawerSave = (
     <>
-      <ContentBox>This is inside a ContentBox</ContentBox>
       <ContentBox title="Contentbox with title">
         This is inside another with a title ContentBox
       </ContentBox>
+      <ContentBox>This is inside a ContentBox</ContentBox>
     </>
   );
   const drawerHelp = <>Help content</>;


### PR DESCRIPTION
This adds the contentbox component to the library, which we can use to wrap the different operations we are going to have in the sidebar in the web app.

I am a bit unsure if it should be added to the web app components, or be added in the ui library like I have done.

Also added some basic tests and stories, and updated the NavigationDrawer to better fit the intended use.