### PR TITLE
Fix the installation of the i18next packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,12 @@
       ],
       "dependencies": {
         "@uidotdev/usehooks": "^2.4.1",
+        "i18next": "^25.2.1",
+        "i18next-browser-languagedetector": "^8.2.0",
+        "i18next-http-backend": "^3.0.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-i18next": "^15.5.3",
         "react-virtuoso": "^4.13.0",
         "sass": "^1.89.2",
         "vite": "^6.3.5"
@@ -5988,9 +5992,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "24.2.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.2.tgz",
-      "integrity": "sha512-NE6i86lBCKRYZa5TaUDkU5S4HFgLIEJRLr3Whf2psgaxBleQ2LC1YW1Vc+SCgkAW7VEzndT6al6+CzegSUHcTQ==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
+      "integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
       "funding": [
         {
           "type": "individual",
@@ -6006,9 +6010,8 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.23.2"
+        "@babel/runtime": "^7.27.1"
       },
       "peerDependencies": {
         "typescript": "^5"
@@ -10623,8 +10626,6 @@
         "@emotion/is-prop-valid": "^1.3.1",
         "@pxweb2/pxweb2-ui": "*",
         "framer-motion": "^12.18.1",
-        "i18next-browser-languagedetector": "^8.2.0",
-        "i18next-http-backend": "^3.0.2",
         "react-router": "^7.6.2"
       },
       "devDependencies": {
@@ -10651,7 +10652,6 @@
         "@vitejs/plugin-react": "^4.5.2",
         "clsx": "^2.1.1",
         "motion": "^12.18.1",
-        "react-i18next": "^15.5.3",
         "vite-plugin-dts": "^4.5.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,12 @@
   "private": true,
   "dependencies": {
     "@uidotdev/usehooks": "^2.4.1",
+    "i18next": "^25.2.1",
+    "i18next-browser-languagedetector": "^8.2.0",
+    "i18next-http-backend": "^3.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-i18next": "^15.5.3",
     "react-virtuoso": "^4.13.0",
     "sass": "^1.89.2",
     "vite": "^6.3.5"

--- a/packages/pxweb2-ui/package.json
+++ b/packages/pxweb2-ui/package.json
@@ -20,7 +20,6 @@
     "@vitejs/plugin-react": "^4.5.2",
     "clsx": "^2.1.1",
     "motion": "^12.18.1",
-    "react-i18next": "^15.5.3",
     "vite-plugin-dts": "^4.5.4"
   },
   "devDependencies": {

--- a/packages/pxweb2/package.json
+++ b/packages/pxweb2/package.json
@@ -21,8 +21,6 @@
     "@emotion/is-prop-valid": "^1.3.1",
     "@pxweb2/pxweb2-ui": "*",
     "framer-motion": "^12.18.1",
-    "i18next-browser-languagedetector": "^8.2.0",
-    "i18next-http-backend": "^3.0.2",
     "react-router": "^7.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The current installation of the different packages for i18next, are a bit inconsistent and missing. Some are installed in the web app, another is installed in the ui lib, and the i18next main package is missing entirely. This fixes the packages installations by installing them in the root package.json, so they can be used in the web app and ui lib as needed.

We can move them into specific packages later if we need to.