### PR TITLE
Wrap the SaveToFile ActionItems in a list

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.tsx
@@ -6,15 +6,16 @@ import Heading from '../Typography/Heading/Heading';
 
 interface ContentBoxProps {
   readonly title?: string;
+  readonly titleDivId?: string;
   readonly children: ReactNode;
 }
 
-export function ContentBox({ title, children }: ContentBoxProps) {
+export function ContentBox({ title, titleDivId, children }: ContentBoxProps) {
   return (
     <div className={cl(styles.contentBox)}>
       {title && (
         <div className={cl(styles.title)}>
-          <Heading level={'3'} size={'small'}>
+          <Heading level={'3'} size={'small'} id={titleDivId}>
             {title}
           </Heading>
         </div>

--- a/packages/pxweb2/src/app/components/NavigationDrawer/Drawers/DrawerSave.module.scss
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/Drawers/DrawerSave.module.scss
@@ -12,3 +12,9 @@
   margin: 0; // Remove margin so centering is exact
   align-self: auto; // Remove align-self so absolute positioning works
 }
+
+.saveAsActionList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}

--- a/packages/pxweb2/src/app/components/NavigationDrawer/Drawers/DrawerSave.tsx
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/Drawers/DrawerSave.tsx
@@ -94,39 +94,58 @@ export function DrawerSave({ tableId }: DrawerSaveProps) {
 
   return (
     <div className={cl(classes.drawerSave)}>
-      <ContentBox title={t('presentation_page.sidemenu.save.file.title')}>
-        <div>
-          <ActionItem
-            ariaLabel={t('presentation_page.sidemenu.save.file.excel')}
-            onClick={() => saveToFile('excel')}
-            iconName="FileText"
-          />
-          <ActionItem
-            ariaLabel={t('presentation_page.sidemenu.save.file.csv')}
-            onClick={() => saveToFile('csv')}
-            iconName="FileText"
-          />
-          <ActionItem
-            ariaLabel={t('presentation_page.sidemenu.save.file.px')}
-            onClick={() => saveToFile('px')}
-            iconName="FileCode"
-          />
-          <ActionItem
-            ariaLabel={t('presentation_page.sidemenu.save.file.jsonstat2')}
-            onClick={() => saveToFile('jsonstat2')}
-            iconName="FileCode"
-          />
-          <ActionItem
-            ariaLabel={t('presentation_page.sidemenu.save.file.html')}
-            onClick={() => saveToFile('html')}
-            iconName="FileCode"
-          />
-          <ActionItem
-            ariaLabel={t('presentation_page.sidemenu.save.file.parquet')}
-            onClick={() => saveToFile('parquet')}
-            iconName="FileCode"
-          />
-        </div>
+      <ContentBox
+        titleDivId="drawer-save-to-file"
+        title={t('presentation_page.sidemenu.save.file.title')}
+      >
+        <ul
+          className={classes.saveAsActionList}
+          role="list"
+          aria-labelledby="drawer-save-to-file"
+        >
+          <li>
+            <ActionItem
+              ariaLabel={t('presentation_page.sidemenu.save.file.excel')}
+              onClick={() => saveToFile('excel')}
+              iconName="FileText"
+            />
+          </li>
+          <li>
+            <ActionItem
+              ariaLabel={t('presentation_page.sidemenu.save.file.csv')}
+              onClick={() => saveToFile('csv')}
+              iconName="FileText"
+            />
+          </li>
+          <li>
+            <ActionItem
+              ariaLabel={t('presentation_page.sidemenu.save.file.px')}
+              onClick={() => saveToFile('px')}
+              iconName="FileCode"
+            />
+          </li>
+          <li>
+            <ActionItem
+              ariaLabel={t('presentation_page.sidemenu.save.file.jsonstat2')}
+              onClick={() => saveToFile('jsonstat2')}
+              iconName="FileCode"
+            />
+          </li>
+          <li>
+            <ActionItem
+              ariaLabel={t('presentation_page.sidemenu.save.file.html')}
+              onClick={() => saveToFile('html')}
+              iconName="FileCode"
+            />
+          </li>
+          <li>
+            <ActionItem
+              ariaLabel={t('presentation_page.sidemenu.save.file.parquet')}
+              onClick={() => saveToFile('parquet')}
+              iconName="FileCode"
+            />
+          </li>
+        </ul>
         {isLoading && (
           <div className={classes.loadingSpinner}>
             <Spinner size="xlarge" />


### PR DESCRIPTION
The buttons for saving a table to the different file formats, needs to be inside a list for easier screen reading. The list should also be linked to the appropriate title with aria-labelled by, so the correct message is read to the user when navigating into the list.