### PR TITLE
Change when NavDrawer is open by default

### DIFF
--- a/packages/pxweb2/src/app/context/AppProvider.tsx
+++ b/packages/pxweb2/src/app/context/AppProvider.tsx
@@ -3,11 +3,13 @@ import React, { createContext, useState, useEffect, useMemo } from 'react';
 import {
   BreakpointsXsmallMaxWidth,
   BreakpointsMediumMaxWidth,
+  BreakpointsLargeMaxWidth,
 } from '@pxweb2/pxweb2-ui';
 
 // Define the type for the context
 export type AppContextType = {
   isInitialized: boolean;
+  isLargeDesktop: boolean;
   isTablet: boolean;
   isMobile: boolean;
   skipToMainFocused: boolean;
@@ -17,6 +19,7 @@ export type AppContextType = {
 // Create the context with default values
 export const AppContext = createContext<AppContextType>({
   isInitialized: false,
+  isLargeDesktop: false,
   isTablet: false,
   isMobile: false,
   skipToMainFocused: false,
@@ -35,8 +38,12 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   /**
    * Keep state if window screen size is mobile, pad or desktop.
    */
+  const largeBreakpoint = Number(BreakpointsLargeMaxWidth.replace('px', ''));
   const tabletBreakpoint = Number(BreakpointsMediumMaxWidth.replace('px', ''));
   const mobileBreakpoint = Number(BreakpointsXsmallMaxWidth.replace('px', ''));
+  const [isLargeDesktop, setIsLargeDesktop] = useState(
+    window.innerWidth > largeBreakpoint,
+  );
   const [isTablet, setIsTablet] = useState(
     window.innerWidth <= tabletBreakpoint,
   );
@@ -47,6 +54,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   // Use effect to set the isMobile and isTablet state
   useEffect(() => {
     const handleResize = () => {
+      setIsLargeDesktop(window.innerWidth > largeBreakpoint);
       setIsTablet(window.innerWidth <= tabletBreakpoint);
       setIsMobile(window.innerWidth <= mobileBreakpoint);
     };
@@ -56,11 +64,12 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [mobileBreakpoint, tabletBreakpoint]);
+  }, [mobileBreakpoint, tabletBreakpoint, largeBreakpoint]);
 
   const cachedValues = useMemo(
     () => ({
       isInitialized,
+      isLargeDesktop,
       isTablet,
       isMobile,
       skipToMainFocused,
@@ -68,6 +77,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     }),
     [
       isInitialized,
+      isLargeDesktop,
       isTablet,
       isMobile,
       skipToMainFocused,

--- a/packages/pxweb2/src/app/pages/TableViewer/TableViewer.tsx
+++ b/packages/pxweb2/src/app/pages/TableViewer/TableViewer.tsx
@@ -22,8 +22,13 @@ import { TableDataProvider } from '../../context/TableDataProvider';
 import ErrorBoundary from '../../components/ErrorBoundry/ErrorBoundry';
 
 export function TableViewer() {
-  const { isMobile, isTablet, skipToMainFocused, setSkipToMainFocused } =
-    useApp();
+  const {
+    isMobile,
+    isTablet,
+    isLargeDesktop,
+    skipToMainFocused,
+    setSkipToMainFocused,
+  } = useApp();
   const config = getConfig();
   const accessibility = useAccessibility();
 
@@ -36,7 +41,7 @@ export function TableViewer() {
   const [selectedTableId] = useState(tableId ?? 'tab638');
   const [errorMsg] = useState('');
   const [selectedNavigationView, setSelectedNavigationView] =
-    useState<NavigationItem>(isTablet ? 'none' : 'selection');
+    useState<NavigationItem>(isLargeDesktop ? 'selection' : 'none');
   const [hasFocus, setHasFocus] = useState<NavigationItem>('none');
   const [openedWithKeyboard, setOpenedWithKeyboard] = useState(false);
   const outerContainerRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
This changes when the NavDrawer is opened by default on initial table page load. Since we found issues with focus being hidden behind it, it was decided that a better solution for keyboard users is to not start in a state where focus can be hidden. Now only shows it by default on larger than the large breakpoint.

Considered adding a simpler check in TableViewer, but decided to expand the solution for checking window width in the AppProvider. To be consistent with previous solutions.