### PR TITLE
Add first value when changing codelist for mandvar

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBox.tsx
@@ -20,10 +20,7 @@ export type VariableBoxProps = VariableBoxPropsBase & {
   tableId: string;
   languageDirection: 'ltr' | 'rtl';
   initialIsOpen?: boolean;
-  onChangeCodeList: (
-    selectedItem: SelectOption | undefined,
-    varId: string,
-  ) => void;
+  onChangeCodeList: (selectedItem: SelectOption, varId: string) => void;
   onChangeCheckbox: (varId: string, value: string) => void;
   onChangeMixedCheckbox: (
     varId: string,

--- a/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableBox/VariableBoxContent/VariableBoxContent.tsx
@@ -36,10 +36,7 @@ type VariableBoxContentProps = VariableBoxPropsToContent & {
   totalValues: number;
   totalChosenValues: number;
   languageDirection: 'ltr' | 'rtl';
-  onChangeCodeList: (
-    selectedItem: SelectOption | undefined,
-    varId: string,
-  ) => void;
+  onChangeCodeList: (selectedItem: SelectOption, varId: string) => void;
   onChangeCheckbox: (varId: string, value: string) => void;
   onChangeMixedCheckbox: (
     varId: string,
@@ -217,7 +214,7 @@ export function VariableBoxContent({
   const selectedCodeListOrUndefined = selectedCodeListMapped ?? undefined;
 
   const handleChangingCodeListInVariableBox = (
-    selectedItem: SelectOption | undefined,
+    selectedItem: SelectOption,
     varId: string,
     virtuosoRef: React.RefObject<VirtuosoHandle | null>,
   ) => {
@@ -473,6 +470,7 @@ export function VariableBoxContent({
               options={mappedAndSortedCodeLists}
               selectedOption={selectedCodeListOrUndefined}
               onChange={(selectedItem) =>
+                selectedItem &&
                 handleChangingCodeListInVariableBox(
                   selectedItem,
                   varId,

--- a/packages/pxweb2-ui/src/lib/components/VariableList/VariableList.tsx
+++ b/packages/pxweb2-ui/src/lib/components/VariableList/VariableList.tsx
@@ -15,10 +15,7 @@ export type VariableListProps = {
   selectedVBValues: SelectedVBValues[];
 
   // TODO: Optimise here? Duplicate with props in VariableBox
-  handleCodeListChange: (
-    selectedItem: SelectOption | undefined,
-    varId: string,
-  ) => void;
+  handleCodeListChange: (selectedItem: SelectOption, varId: string) => void;
   handleCheckboxChange: (varId: string, value: string) => void;
   handleMixedCheckboxChange: (
     varId: string,

--- a/packages/pxweb2/src/app/components/Selection/Selection.tsx
+++ b/packages/pxweb2/src/app/components/Selection/Selection.tsx
@@ -335,7 +335,7 @@ export function Selection({
   }
 
   async function handleCodeListChange(
-    selectedItem: SelectOption | undefined,
+    selectedItem: SelectOption,
     varId: string,
   ) {
     const lang = i18n.resolvedLanguage;
@@ -355,13 +355,11 @@ export function Selection({
 
     const prevSelectedValues = structuredClone(selectedVBValues);
 
-    const newSelectedValues = updateSelectedCodelistForVariable(
-      selectedItem,
-      varId,
-      prevSelectedValues,
-      currentVariableMetadata,
-    );
-    if (!newSelectedValues) {
+    const isNewCodelist =
+      prevSelectedValues?.find((variable) => variable.id === varId)
+        ?.selectedCodeList !== selectedItem?.value;
+
+    if (!isNewCodelist) {
       return; // No change in codelist selection
     }
 
@@ -388,6 +386,20 @@ export function Selection({
 
         if (pxTableMetaToRender !== null) {
           setPxTableMetaToRender(null);
+        }
+
+        const newSelectedValues = updateSelectedCodelistForVariable(
+          selectedItem,
+          varId,
+          prevSelectedValues,
+          currentVariableMetadata,
+          pxTable.metadata,
+        );
+
+        if (!newSelectedValues) {
+          throw new Error(
+            `Could not update selected codelist for variable: ${varId}`,
+          );
         }
 
         // UpdateAndSyncVBValues with the new selected values to trigger API data-call

--- a/packages/pxweb2/src/app/components/Selection/selectionUtils.spec.ts
+++ b/packages/pxweb2/src/app/components/Selection/selectionUtils.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+
 import {
   updateSelectedCodelistForVariable,
   addSelectedCodeListToVariable,
@@ -9,6 +10,7 @@ import {
   SelectOption,
   Variable,
   VartypeEnum,
+  PxTableMetadata,
 } from '@pxweb2/pxweb2-ui';
 
 describe('selectionUtils', () => {
@@ -38,44 +40,68 @@ describe('selectionUtils', () => {
   });
 
   describe('setSelectedCodelist', () => {
-    it('returns undefined if no selectedItem is provided', () => {
-      const result = updateSelectedCodelistForVariable(
-        undefined,
-        varId,
-        prevSelectedValues,
-        variableMeta,
-      );
-      expect(result).toBeUndefined();
-    });
-
-    it('returns undefined if selectedItem.value equals current selectedCodeList', () => {
-      const result = updateSelectedCodelistForVariable(
-        selectOptionA,
-        varId,
-        prevSelectedValues,
-        variableMeta,
-      );
-      expect(result).toBeUndefined();
-    });
-
     it('returns undefined if newSelectedCodeList is not found', () => {
       const invalidOption: SelectOption = { label: 'Invalid', value: 'Z' };
+      const mockMetadata: PxTableMetadata = {
+        variables: [variableMeta],
+        id: 'test-table',
+        language: 'en',
+        label: 'Test Table',
+        description: 'Test description',
+        source: 'Test source',
+        updated: new Date('2024-01-01'),
+        infofile: 'test.info',
+        decimals: 2,
+        officialStatistics: false,
+        aggregationAllowed: false,
+        contents: 'Test contents',
+        descriptionDefault: false,
+        matrix: 'test-matrix',
+        subjectCode: 'test-subject',
+        subjectArea: 'test-area',
+        contacts: [],
+        notes: [],
+      };
       const result = updateSelectedCodelistForVariable(
         invalidOption,
         varId,
         prevSelectedValues,
         variableMeta,
+        mockMetadata,
       );
+
       expect(result).toBeUndefined();
     });
 
     it('returns new selected values when a new codelist is selected', () => {
+      const mockMetadata: PxTableMetadata = {
+        variables: [variableMeta],
+        id: 'test-table',
+        language: 'en',
+        label: 'Test Table',
+        description: 'Test description',
+        source: 'Test source',
+        updated: new Date('2024-01-01'),
+        infofile: 'test.info',
+        decimals: 2,
+        officialStatistics: false,
+        aggregationAllowed: false,
+        contents: 'Test contents',
+        descriptionDefault: false,
+        matrix: 'test-matrix',
+        subjectCode: 'test-subject',
+        subjectArea: 'test-area',
+        contacts: [],
+        notes: [],
+      };
       const result = updateSelectedCodelistForVariable(
         selectOptionB,
         varId,
         prevSelectedValues,
         variableMeta,
+        mockMetadata,
       );
+
       expect(result).toBeDefined();
       expect(result?.find((v) => v.id === varId)?.selectedCodeList).toBe('B');
       expect(result?.find((v) => v.id === varId)?.values).toEqual([]);
@@ -91,15 +117,183 @@ describe('selectionUtils', () => {
         mandatory: false,
         values: [],
       };
+      const mockMetadata: PxTableMetadata = {
+        variables: [newMeta],
+        id: 'test-table',
+        language: 'en',
+        label: 'Test Table',
+        description: 'Test description',
+        source: 'Test source',
+        updated: new Date('2024-01-01'),
+        infofile: 'test.info',
+        decimals: 2,
+        officialStatistics: false,
+        aggregationAllowed: false,
+        contents: 'Test contents',
+        descriptionDefault: false,
+        matrix: 'test-matrix',
+        subjectCode: 'test-subject',
+        subjectArea: 'test-area',
+        contacts: [],
+        notes: [],
+      };
       const result = updateSelectedCodelistForVariable(
         selectOptionA,
         newVarId,
         prevSelectedValues,
         newMeta,
+        mockMetadata,
       );
+
       expect(result?.find((v) => v.id === newVarId)?.selectedCodeList).toBe(
         'A',
       );
+    });
+
+    it('applies mandatory defaults', () => {
+      const mandatoryVariable: Variable = {
+        id: varId,
+        codeLists: [codeListB],
+        label: '',
+        type: VartypeEnum.CONTENTS_VARIABLE,
+        mandatory: true,
+        values: [
+          { code: 'default1', label: 'Default 1' },
+          { code: 'default2', label: 'Default 2' },
+        ],
+      };
+      const mockMetadata: PxTableMetadata = {
+        variables: [mandatoryVariable],
+        id: 'test-table',
+        language: 'en',
+        label: 'Test Table',
+        description: 'Test description',
+        source: 'Test source',
+        updated: new Date('2024-01-01'),
+        infofile: 'test.info',
+        decimals: 2,
+        officialStatistics: false,
+        aggregationAllowed: false,
+        contents: 'Test contents',
+        descriptionDefault: false,
+        matrix: 'test-matrix',
+        subjectCode: 'test-subject',
+        subjectArea: 'test-area',
+        contacts: [],
+        notes: [],
+      };
+      const result = updateSelectedCodelistForVariable(
+        selectOptionB,
+        varId,
+        prevSelectedValues,
+        mandatoryVariable,
+        mockMetadata,
+      );
+
+      expect(result?.find((v) => v.id === varId)?.values).toEqual(['default1']);
+    });
+
+    it('does not apply mandatory defaults when variable is not mandatory', () => {
+      const nonMandatoryVariable: Variable = {
+        id: varId,
+        codeLists: [codeListB],
+        label: '',
+        type: VartypeEnum.CONTENTS_VARIABLE,
+        mandatory: false,
+        values: [{ code: 'value1', label: 'Value 1' }],
+      };
+      const mockMetadata: PxTableMetadata = {
+        variables: [nonMandatoryVariable],
+        id: 'test-table',
+        language: 'en',
+        label: 'Test Table',
+        description: 'Test description',
+        source: 'Test source',
+        updated: new Date('2024-01-01'),
+        infofile: 'test.info',
+        decimals: 2,
+        officialStatistics: false,
+        aggregationAllowed: false,
+        contents: 'Test contents',
+        descriptionDefault: false,
+        matrix: 'test-matrix',
+        subjectCode: 'test-subject',
+        subjectArea: 'test-area',
+        contacts: [],
+        notes: [],
+      };
+      const result = updateSelectedCodelistForVariable(
+        selectOptionB,
+        varId,
+        prevSelectedValues,
+        nonMandatoryVariable,
+        mockMetadata,
+      );
+
+      expect(result?.find((v) => v.id === varId)?.values).toEqual([]);
+    });
+
+    it('does not apply mandatory defaults to other mandatory variables than the one with new codelist', () => {
+      const varId2 = 'var2';
+      const mandatoryVariable: Variable = {
+        id: varId,
+        codeLists: [codeListB],
+        label: '',
+        type: VartypeEnum.CONTENTS_VARIABLE,
+        mandatory: true,
+        values: [{ code: 'default1', label: 'Default 1' }],
+      };
+      const mandatoryVariable2: Variable = {
+        id: varId2,
+        codeLists: [codeListA],
+        label: '',
+        type: VartypeEnum.CONTENTS_VARIABLE,
+        mandatory: true,
+        values: [{ code: 'default2', label: 'Default 2' }],
+      };
+      const mockMetadata: PxTableMetadata = {
+        variables: [mandatoryVariable, mandatoryVariable2],
+        id: 'test-table',
+        language: 'en',
+        label: 'Test Table',
+        description: 'Test description',
+        source: 'Test source',
+        updated: new Date('2024-01-01'),
+        infofile: 'test.info',
+        decimals: 2,
+        officialStatistics: false,
+        aggregationAllowed: false,
+        contents: 'Test contents',
+        descriptionDefault: false,
+        matrix: 'test-matrix',
+        subjectCode: 'test-subject',
+        subjectArea: 'test-area',
+        contacts: [],
+        notes: [],
+      };
+      const prevValuesWithData = [
+        { id: varId, selectedCodeList: 'A', values: ['existing'] },
+        {
+          id: varId2,
+          selectedCodeList: 'C',
+          values: ['existing-value-1', 'existing-value-2'],
+        },
+      ];
+      const result = updateSelectedCodelistForVariable(
+        selectOptionB,
+        varId,
+        prevValuesWithData,
+        mandatoryVariable,
+        mockMetadata,
+      );
+
+      // The variable we're updating should get reset and receive the default,
+      // and the other mandatory variable should keep its existing values unchanged
+      expect(result?.find((v) => v.id === varId)?.values).toEqual(['default1']);
+      expect(result?.find((v) => v.id === varId2)?.values).toEqual([
+        'existing-value-1',
+        'existing-value-2',
+      ]);
     });
   });
 


### PR DESCRIPTION
This adds the logic for adding default values, when changing codelists for mandatory variables. The values chosen is limited to the first value, but the code should be easily extendable to be expanded later. This is why I chose to have the logic for adding the defaults seperated from adding codelist to variables. Any extra processing should not have a significant impact, since we are only mapping over variables here, and not values.

Also updated the tests.