### PR TITLE
Fix eslint warnings about PascalCase for Stories

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Alert/Alert.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Alert/Alert.stories.tsx
@@ -28,7 +28,7 @@ export const Variant = {
   },
 };
 
-export const withlink: StoryFn<typeof Alert> = () => {
+export const WithLink: StoryFn<typeof Alert> = () => {
   return (
     <>
       <br />
@@ -43,7 +43,7 @@ export const withlink: StoryFn<typeof Alert> = () => {
   );
 };
 
-export const withtextandlink: StoryFn<typeof Alert> = () => {
+export const WithTextAndLink: StoryFn<typeof Alert> = () => {
   return (
     <>
       <br />
@@ -59,7 +59,7 @@ export const withtextandlink: StoryFn<typeof Alert> = () => {
   );
 };
 
-export const withOLList: StoryFn<typeof Alert> = () => {
+export const WithOLList: StoryFn<typeof Alert> = () => {
   return (
     <Alert variant="info" heading="Heading alert" clickable closeButton>
       <List listType="ol" heading="Heading list">
@@ -75,7 +75,7 @@ export const withOLList: StoryFn<typeof Alert> = () => {
     </Alert>
   );
 };
-export const withULList: StoryFn<typeof Alert> = () => {
+export const WithULList: StoryFn<typeof Alert> = () => {
   return (
     <Alert variant="info" heading="Heading alert from notes" closeButton>
       <List listType="ul">
@@ -103,7 +103,7 @@ export const withULList: StoryFn<typeof Alert> = () => {
   );
 };
 
-export const withULListClickable: StoryFn<typeof Alert> = () => {
+export const WithULListClickable: StoryFn<typeof Alert> = () => {
   return (
     <Alert
       variant="info"
@@ -136,7 +136,7 @@ export const withULListClickable: StoryFn<typeof Alert> = () => {
   );
 };
 
-export const withListgroupClickable: StoryFn<typeof Alert> = () => {
+export const WithListgroupClickable: StoryFn<typeof Alert> = () => {
   return (
     <Alert variant="info" heading="Heading Alert" closeButton clickable>
       <List heading="Land" subHeading="Subheading" listType="ul" listGroup>
@@ -177,7 +177,7 @@ export const withListgroupClickable: StoryFn<typeof Alert> = () => {
   );
 };
 
-export const test: StoryFn<typeof Alert> = () => {
+export const Test: StoryFn<typeof Alert> = () => {
   return (
     <Alert variant="info" heading="Heading Alert" closeButton clickable>
       <List listType="ul">

--- a/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/ContentBox/ContentBox.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof ContentBox> = {
 export default meta;
 type Story = StoryObj<typeof ContentBox>;
 
-export const withTitle: Story = {
+export const WithTitle: Story = {
   name: 'With title',
   args: {
     title: 'Edit',
@@ -31,14 +31,14 @@ export const withTitle: Story = {
   },
 };
 
-export const withoutTitle: Story = {
+export const WithoutTitle: Story = {
   name: 'Without title',
   args: {
     children: <span>Children goes here</span>,
   },
 };
 
-export const withLongContent: Story = {
+export const WithLongContent: Story = {
   name: 'With long content',
   args: {
     title: 'Long Content Example',

--- a/packages/pxweb2-ui/src/lib/components/Link/Link.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Link/Link.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 
 type Story = StoryObj<typeof Link>;
 
-export const variants: Story = {
+export const Variants: Story = {
   args: {
     href: '#',
     children: 'En godt skrevet lenketekst',
@@ -19,7 +19,7 @@ export const variants: Story = {
   },
 };
 
-export const inlineAndStandalone: StoryFn<typeof BodyLong> = () => {
+export const InlineAndStandalone: StoryFn<typeof BodyLong> = () => {
   return (
     <>
       <h1>Inline link in BodyLong</h1>

--- a/packages/pxweb2-ui/src/lib/components/Radio/Radio.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Radio/Radio.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
   },
 };
 
-export const inModal: StoryFn<typeof Radio> = () => {
+export const InModal: StoryFn<typeof Radio> = () => {
   return (
     <Radio
       name="radio1"

--- a/packages/pxweb2-ui/src/lib/components/Spinner/Spinner.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Spinner/Spinner.stories.tsx
@@ -20,7 +20,7 @@ export const Options = {
   },
 };
 
-export const size: StoryFn<typeof Spinner> = () => {
+export const Size: StoryFn<typeof Spinner> = () => {
   return (
     <>
       <div>
@@ -47,7 +47,7 @@ export const size: StoryFn<typeof Spinner> = () => {
   );
 };
 
-export const variants: StoryFn<typeof Spinner> = () => {
+export const Variants: StoryFn<typeof Spinner> = () => {
   return (
     <>
       <div>
@@ -61,7 +61,7 @@ export const variants: StoryFn<typeof Spinner> = () => {
     </>
   );
 };
-export const label: StoryFn<typeof Spinner> = () => {
+export const Label: StoryFn<typeof Spinner> = () => {
   return (
     <>
       <div>

--- a/packages/pxweb2-ui/src/lib/components/TableCard/TableCard.stories.tsx
+++ b/packages/pxweb2-ui/src/lib/components/TableCard/TableCard.stories.tsx
@@ -32,7 +32,7 @@ export const Default: Story = {
   },
 };
 
-export const withoutIcon: StoryFn<typeof TableCard> = () => {
+export const WithoutIcon: StoryFn<typeof TableCard> = () => {
   return (
     <TableCard
       href="/"
@@ -46,7 +46,7 @@ export const withoutIcon: StoryFn<typeof TableCard> = () => {
   );
 };
 
-export const withoutTableNumber: StoryFn<typeof TableCard> = () => {
+export const WithoutTableNumber: StoryFn<typeof TableCard> = () => {
   return (
     <TableCard
       href="/"


### PR DESCRIPTION
This fixes all the current warnings about PascalCase for Stories, that we get when running the lint command. Many had camelCase, including one story file.