### PR TITLE
Update the translationkeys for saveToFile formats

### DIFF
--- a/packages/pxweb2/public/locales/ar/translation.json
+++ b/packages/pxweb2/public/locales/ar/translation.json
@@ -141,12 +141,14 @@
         "file": {
           "title": "حفظ كملف",
           "loading_announcement": "الملف لا يزال قيد المعالجة. يرجى الانتظار.",
-          "excel": "اكسل (xlsx)",
-          "csv": "مفصولة بفاصلة منقوطة مع عنوان (.csv)",
-          "px": "PC-Axis (.px)",
-          "jsonstat2": "JSON-stat2 (.json)",
-          "html": "HTML (.html)",
-          "parquet": "Parquet (.parquet)"
+          "formats": {
+            "excel": "اكسل (xlsx)",
+            "csv": "مفصولة بفاصلة منقوطة مع عنوان (.csv)",
+            "px": "PC-Axis (.px)",
+            "jsonstat2": "JSON-stat2 (.json)",
+            "html": "HTML (.html)",
+            "parquet": "Parquet (.parquet)"
+          }
         },
         "savequery": {
           "title": "رابط إلى الجدول المحدث",

--- a/packages/pxweb2/public/locales/en/translation.json
+++ b/packages/pxweb2/public/locales/en/translation.json
@@ -182,12 +182,14 @@
         "file": {
           "title": "Download as file",
           "loading_announcement": "File is still being processed. Please wait.",
-          "excel": "Excel (.xlsx)",
-          "csv": "Semicolon-delimited with heading (.csv)",
-          "px": "PC-Axis (.px)",
-          "jsonstat2": "JSON-stat2 (.json)",
-          "html": "HTML (.html)",
-          "parquet": "Parquet (.parquet)"
+          "formats": {
+            "excel": "Excel (.xlsx)",
+            "csv": "Semicolon-delimited with heading (.csv)",
+            "px": "PC-Axis (.px)",
+            "jsonstat2": "JSON-stat2 (.json)",
+            "html": "HTML (.html)",
+            "parquet": "Parquet (.parquet)"
+          }
         },
         "savequery": {
           "title": "Link to updated table",

--- a/packages/pxweb2/public/locales/no/translation.json
+++ b/packages/pxweb2/public/locales/no/translation.json
@@ -182,12 +182,14 @@
         "file": {
           "title": "Last ned som fil",
           "loading_announcement": "Filen behandles fortsatt. Vennligst vent.",
-          "excel": "Excel (.xlsx)",
-          "csv": "Semikolonseparert med overskrift (.csv)",
-          "px": "PC-Axis (.px)",
-          "jsonstat2": "JSON-stat2 (.json)",
-          "html": "HTML (.html)",
-          "parquet": "Parquet (.parquet)"
+          "formats": {
+            "excel": "Excel (.xlsx)",
+            "csv": "Semikolonseparert med overskrift (.csv)",
+            "px": "PC-Axis (.px)",
+            "jsonstat2": "JSON-stat2 (.json)",
+            "html": "HTML (.html)",
+            "parquet": "Parquet (.parquet)"
+          }
         },
         "savequery": {
           "title": "Lenke til oppdatert tabell",

--- a/packages/pxweb2/public/locales/sv/translation.json
+++ b/packages/pxweb2/public/locales/sv/translation.json
@@ -182,12 +182,14 @@
         "file": {
           "title": "Spara som fil",
           "loading_announcement": "Filen bearbetas fortfarande. Vänligen vänta.",
-          "excel": "Excel (.xlsx)",
-          "csv": "Semikolonavgränsad med rubrik (.csv)",
-          "px": "PC-Axis (.px)",
-          "jsonstat2": "JSON-stat2 (.json)",
-          "html": "HTML (.html)",
-          "parquet": "Parquet (.parquet)"
+          "formats": {
+            "excel": "Excel (.xlsx)",
+            "csv": "Semikolonavgränsad med rubrik (.csv)",
+            "px": "PC-Axis (.px)",
+            "jsonstat2": "JSON-stat2 (.json)",
+            "html": "HTML (.html)",
+            "parquet": "Parquet (.parquet)"
+          }
         },
         "savequery": {
           "title": "Länk till uppdaterad tabell",

--- a/packages/pxweb2/src/@types/resources.d.ts
+++ b/packages/pxweb2/src/@types/resources.d.ts
@@ -186,12 +186,14 @@ interface Resources {
           file: {
             title: 'Download as file';
             loading_announcement: 'File is still being processed. Please wait.';
-            excel: 'Excel (.xlsx)';
-            csv: 'Semicolon-delimited with heading (.csv)';
-            px: 'PC-Axis (.px)';
-            jsonstat2: 'JSON-stat2 (.json)';
-            html: 'HTML (.html)';
-            parquet: 'Parquet (.parquet)';
+            formats: {
+              excel: 'Excel (.xlsx)';
+              csv: 'Semicolon-delimited with heading (.csv)';
+              px: 'PC-Axis (.px)';
+              jsonstat2: 'JSON-stat2 (.json)';
+              html: 'HTML (.html)';
+              parquet: 'Parquet (.parquet)';
+            };
           };
           savequery: {
             title: 'Link to updated table';

--- a/packages/pxweb2/src/app/components/NavigationDrawer/Drawers/DrawerSave.tsx
+++ b/packages/pxweb2/src/app/components/NavigationDrawer/Drawers/DrawerSave.tsx
@@ -485,7 +485,7 @@ export function DrawerSave({ tableId }: DrawerSaveProps) {
             <li key={`saveToFile${format.value}`}>
               <ActionItem
                 ariaLabel={t(
-                  `presentation_page.sidemenu.save.file.${format.value}`, // Not sure how to fix this i18next type error
+                  `presentation_page.sidemenu.save.file.formats.${format.value}`, // Not sure how to fix this i18next type error
                 )}
                 onClick={() => saveToFile(format.outputFormat)}
                 iconName={format.iconName}


### PR DESCRIPTION
Move the fileformats for the saveToFile translation keys into their own sub part, to make it clearer what is a fileformat and what is not, in the translation files.