### PR TITLE
Remove contentcode variables from the table title

### DIFF
--- a/packages/pxweb2/public/locales/ar/translation.json
+++ b/packages/pxweb2/public/locales/ar/translation.json
@@ -185,7 +185,8 @@
       "arialabelbreadcrumb": "مسار التنقل",
       "last_updated": "آخر تحديث",
       "show_details": "إظهار التفاصيل",
-      "dynamic_table_title": "{{table_content_type}} بعد {{table_content_label_first_part}} و {{table_content_label_last_part}}",
+      "dynamic_table_title_full": "{{table_content_type}} بعد {{table_content_label_first_part}} و {{table_content_label_last_part}}",
+      "dynamic_table_title_one_variable": "{{table_content_type}} بعد {{table_content_label_first_part}}",
       "table": {
         "warnings": {
           "missing_mandatory": {

--- a/packages/pxweb2/public/locales/en/translation.json
+++ b/packages/pxweb2/public/locales/en/translation.json
@@ -226,7 +226,8 @@
       "arialabelbreadcrumb": "Breadcrumb",
       "last_updated": "Last updated",
       "show_details": "Show details",
-      "dynamic_table_title": "{{table_content_type}} by {{table_content_label_first_part}} and {{table_content_label_last_part}}",
+      "dynamic_table_title_full": "{{table_content_type}} by {{table_content_label_first_part}} and {{table_content_label_last_part}}",
+      "dynamic_table_title_one_variable": "{{table_content_type}} by {{table_content_label_first_part}}",
       "table": {
         "warnings": {
           "missing_mandatory": {

--- a/packages/pxweb2/public/locales/no/translation.json
+++ b/packages/pxweb2/public/locales/no/translation.json
@@ -226,7 +226,8 @@
       "arialabelbreadcrumb": "Brødsmulesti",
       "last_updated": "Sist oppdatert",
       "show_details": "Vis detaljer",
-      "dynamic_table_title": "{{table_content_type}} etter {{table_content_label_first_part}} og {{table_content_label_last_part}}",
+      "dynamic_table_title_full": "{{table_content_type}} etter {{table_content_label_first_part}} og {{table_content_label_last_part}}",
+      "dynamic_table_title_one_variable": "{{table_content_type}} etter {{table_content_label_first_part}}",
       "table": {
         "warnings": {
           "missing_mandatory": {

--- a/packages/pxweb2/public/locales/sv/translation.json
+++ b/packages/pxweb2/public/locales/sv/translation.json
@@ -226,7 +226,8 @@
       "arialabelbreadcrumb": "Brödsmulor",
       "last_updated": "Senast uppdaterad",
       "show_details": "Visa detaljer",
-      "dynamic_table_title": "{{table_content_type}} efter {{table_content_label_first_part}} och {{table_content_label_last_part}}",
+      "dynamic_table_title_full": "{{table_content_type}} efter {{table_content_label_first_part}} och {{table_content_label_last_part}}",
+      "dynamic_table_title_one_variable": "{{table_content_type}} efter {{table_content_label_first_part}}",
       "table": {
         "warnings": {
           "missing_mandatory": {

--- a/packages/pxweb2/src/@types/resources.d.ts
+++ b/packages/pxweb2/src/@types/resources.d.ts
@@ -230,7 +230,8 @@ interface Resources {
         arialabelbreadcrumb: 'Breadcrumb';
         last_updated: 'Last updated';
         show_details: 'Show details';
-        dynamic_table_title: '{{table_content_type}} by {{table_content_label_first_part}} and {{table_content_label_last_part}}';
+        dynamic_table_title_full: '{{table_content_type}} by {{table_content_label_first_part}} and {{table_content_label_last_part}}';
+        dynamic_table_title_one_variable: '{{table_content_type}} by {{table_content_label_first_part}}';
         table: {
           warnings: {
             missing_mandatory: {

--- a/packages/pxweb2/src/app/components/ContentTop/ContentTop.tsx
+++ b/packages/pxweb2/src/app/components/ContentTop/ContentTop.tsx
@@ -155,13 +155,25 @@ export function ContentTop({ pxtable, staticTitle }: ContenetTopProps) {
     pxtable.stub,
     pxtable.heading,
   );
+  let tableTitle = '';
 
-  // Example title: "Population by region, observations, year and sex"
-  const tableTitle = t('presentation_page.main_content.dynamic_table_title', {
-    table_content_type: pxtable.metadata.contents,
-    table_content_label_first_part: firstTitlePart,
-    table_content_label_last_part: lastTitlePart,
-  });
+  if (lastTitlePart) {
+    // Example title: "Population by region, year and sex"
+    tableTitle = t('presentation_page.main_content.dynamic_table_title_full', {
+      table_content_type: pxtable.metadata.contents,
+      table_content_label_first_part: firstTitlePart,
+      table_content_label_last_part: lastTitlePart,
+    });
+  } else {
+    // Example title: "Population by region"
+    tableTitle = t(
+      'presentation_page.main_content.dynamic_table_title_one_variable',
+      {
+        table_content_type: pxtable.metadata.contents,
+        table_content_label_first_part: firstTitlePart,
+      },
+    );
+  }
 
   return (
     <>

--- a/packages/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/packages/pxweb2/src/app/context/TableDataProvider.tsx
@@ -32,7 +32,7 @@ export interface TableDataContextType {
   buildTableTitle: (
     stub: Variable[],
     heading: Variable[],
-  ) => { firstTitlePart: string; lastTitlePart: string };
+  ) => { firstTitlePart: string; lastTitlePart: string | undefined };
 }
 
 interface TableDataProviderProps {
@@ -1049,6 +1049,12 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
     } => {
       const titleParts: string[] = [];
       let lastTitlePart: string | undefined = undefined;
+
+      if (stub.length < 1 && heading.length < 1) {
+        throw new Error(
+          'TableDataProvider.buildTableTitle: Both stub and heading are empty',
+        );
+      }
 
       // Add stub variables to title
       stub.forEach((variable) => {

--- a/packages/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/packages/pxweb2/src/app/context/TableDataProvider.tsx
@@ -1058,6 +1058,8 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
 
       /**
        * Issue: Title without ContentsCode variables sometimes does not update when pivoting
+       *  - When only one variable is used in the title
+       *  - When the ContentsCode is the one move to the stub
        *
        * Possible solution: Have different logic for the code that will be used in the PivotButton's aria-label
        * Ask: Bjarte, Vivianne and Maren?

--- a/packages/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/packages/pxweb2/src/app/context/TableDataProvider.tsx
@@ -1056,6 +1056,13 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
         );
       }
 
+      /**
+       * Issue: Title without ContentsCode variables sometimes does not update when pivoting
+       *
+       * Possible solution: Have different logic for the code that will be used in the PivotButton's aria-label
+       * Ask: Bjarte, Vivianne and Maren?
+       */
+
       // Add stub variables to title
       stub.forEach((variable) => {
         if (variable.id !== 'ContentsCode') {

--- a/packages/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/packages/pxweb2/src/app/context/TableDataProvider.tsx
@@ -1045,26 +1045,27 @@ const TableDataProvider: React.FC<TableDataProviderProps> = ({ children }) => {
       heading: Variable[],
     ): {
       firstTitlePart: string;
-      lastTitlePart: string;
+      lastTitlePart: string | undefined;
     } => {
       const titleParts: string[] = [];
+      let lastTitlePart: string | undefined = undefined;
 
       // Add stub variables to title
       stub.forEach((variable) => {
-        titleParts.push(variable.label);
+        if (variable.id !== 'ContentsCode') {
+          titleParts.push(variable.label);
+        }
       });
 
       // Add heading variables to title
       heading.forEach((variable) => {
-        titleParts.push(variable.label);
+        if (variable.id !== 'ContentsCode') {
+          titleParts.push(variable.label);
+        }
       });
 
-      const lastTitlePart = titleParts.pop();
-
-      if (!lastTitlePart) {
-        throw new Error(
-          'TableDataProvider.buildTableTitle: Missing last title part. This should not happen. Please report this as a bug.',
-        );
+      if (titleParts.length > 1) {
+        lastTitlePart = titleParts.pop();
       }
 
       const firstTitlePart = titleParts.join(', ');


### PR DESCRIPTION
This removes the ContentCode variables from the table title, and also adds functionality for when there is only one variable for the table.

Still need to test this on a table with only one variable.