### PR TITLE
Fix/mixed checkbox still shows mixed state with keyboard

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.spec.tsx
@@ -311,7 +311,7 @@ describe('Checkboxes', () => {
       expect(checkmark?.className).toMatch(/checkmarkWithoutMargin/);
     });
 
-    it('should set correct aria attributes', () => {
+    it('should set correct aria attributes when value is true', () => {
       const { getByRole } = render(
         <MixedCheckbox
           id="test-mixed"
@@ -325,6 +325,42 @@ describe('Checkboxes', () => {
       const checkbox = getByRole('checkbox');
 
       expect(checkbox.getAttribute('aria-checked')).toBe('true');
+      expect(checkbox.getAttribute('aria-labelledby')).toBe('test-mixed-label');
+      expect(checkbox.getAttribute('aria-controls')).toBe('item1 item2');
+    });
+
+    it('should set correct aria attributes when value is false', () => {
+      const { getByRole } = render(
+        <MixedCheckbox
+          id="test-mixed"
+          text="Select All"
+          value="false"
+          onChange={() => {}}
+          ariaControls={['item1', 'item2']}
+        />,
+      );
+
+      const checkbox = getByRole('checkbox');
+
+      expect(checkbox.getAttribute('aria-checked')).toBe('false');
+      expect(checkbox.getAttribute('aria-labelledby')).toBe('test-mixed-label');
+      expect(checkbox.getAttribute('aria-controls')).toBe('item1 item2');
+    });
+
+    it('should set correct aria attributes when value is mixed', () => {
+      const { getByRole } = render(
+        <MixedCheckbox
+          id="test-mixed"
+          text="Select All"
+          value="mixed"
+          onChange={() => {}}
+          ariaControls={['item1', 'item2']}
+        />,
+      );
+
+      const checkbox = getByRole('checkbox');
+
+      expect(checkbox.getAttribute('aria-checked')).toBe('false');
       expect(checkbox.getAttribute('aria-labelledby')).toBe('test-mixed-label');
       expect(checkbox.getAttribute('aria-controls')).toBe('item1 item2');
     });

--- a/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Checkbox/Checkbox.tsx
@@ -101,7 +101,7 @@ export const MixedCheckbox: React.FC<MixedCheckboxProps> = ({
     <div
       id={id}
       role="checkbox"
-      aria-checked={value}
+      aria-checked={value === 'true'}
       aria-labelledby={id + '-label'}
       aria-controls={ariaControls.join(' ')}
       className={cl(styles.checkboxWrapper, {


### PR DESCRIPTION
This changes the checked state of the MixedCheckbox component to only show:
 - "true" if all are selected
 - "false" if none or some values are selected

We need to know all three states to properly handle checking and unchecking, based on whether some/none or all are selected, so that logic was not change. This only changes the checked state, for screenreader users.

Also adds test to cover the aria checked state.