### PR TITLE
Creates a package with only the contents of the dist folder

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,10 +27,9 @@ jobs:
       - run: npm ci
       - run: npm run build-artifact
       - name: Create zip file
-        run: zip -r pxweb-${{ env.TAG_NAME }}.zip ./packages/pxweb2/dist
+        run: pushd packages/pxweb2/dist && zip -r $OLDPWD/pxweb-${{ env.TAG_NAME }}.zip ./
       - name: Upload release asset
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload ${{ env.TAG_NAME }} pxweb-${{ env.TAG_NAME }}.zip
-


### PR DESCRIPTION
the zip command is sensitive to the relative path of the files included, and needs to be run from the correct directory in order to not include the folder hierarchy in the archive contents.