### PR TITLE
Remove deprecated vite config code

### DIFF
--- a/packages/pxweb2-ui/vite.config.ts
+++ b/packages/pxweb2-ui/vite.config.ts
@@ -14,13 +14,6 @@ export default defineConfig({
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
     }),
   ],
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
   build: {
     outDir: './dist/',
     reportCompressedSize: true,

--- a/packages/pxweb2/vite.config.ts
+++ b/packages/pxweb2/vite.config.ts
@@ -28,13 +28,6 @@ export default defineConfig({
     port: 4200,
     host: 'localhost',
   },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
   preview: {
     port: 4300,
     host: 'localhost',


### PR DESCRIPTION
Removed Sass legacy API support according to the Vite migration guide to v7.