### PR TITLE
Changed `variable.css` so that it references other css variables 

### DIFF
--- a/packages/pxweb2-ui/style-dictionary/build.mjs
+++ b/packages/pxweb2-ui/style-dictionary/build.mjs
@@ -25,6 +25,7 @@ const configs = [
           {
             destination: 'variables.css',
             format: 'css/variables',
+            options: { outputReferences: true },
           },
         ],
       },
@@ -36,6 +37,7 @@ const configs = [
           {
             destination: 'variables.css',
             format: 'css/variables',
+            options: { outputReferences: true },
           },
         ],
       },


### PR DESCRIPTION
Changed `outputReferences = true` option to CSS variable files so that it generates css variable references instead of the actual value.