### PR TITLE
Remove unused forwardRef from Breadcrumbs

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Breadcrumbs/Breadcrumbs.tsx
@@ -8,8 +8,8 @@ import i18next from 'i18next';
 
 interface BreadcrumbsProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  variant?: 'default' | 'compact';
-  breadcrumbItems: BreadcrumbItem[];
+  readonly variant?: 'default' | 'compact';
+  readonly breadcrumbItems: BreadcrumbItem[];
 }
 
 export class BreadcrumbItem {


### PR DESCRIPTION
This removes an unused forwardRef on the Breadcrumbs component, which was spamming output into every test during test runs. Also, we should not add forwardRef anymore, since it is no longer needed.

Also added some empty lines to divide up the code a bit, and made the props readonly.