### PR TITLE
Switch from href to navigate on tableCard.

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/TableCard/TableCard.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/TableCard/TableCard.spec.tsx
@@ -60,6 +60,18 @@ describe('TableCard', () => {
     window.location = originalLocation;
   });
 
+  it('should execute href function on click', () => {
+    const subLink = () => {
+      return;
+    };
+
+    const { getByRole } = render(<TableCard href={subLink} title="Test" />);
+
+    getByRole('link').click();
+
+    expect(subLink).toHaveBeenCalled;
+  });
+
   it.each(['Enter', ' '])('should navigate on key "%s"', (key) => {
     const originalLocation = window.location;
 

--- a/packages/pxweb2-ui/src/lib/components/TableCard/TableCard.tsx
+++ b/packages/pxweb2-ui/src/lib/components/TableCard/TableCard.tsx
@@ -9,7 +9,7 @@ import { Heading } from '../Typography/Heading/Heading';
 interface TableCardProps {
   ariaLabel?: string;
   frequency?: string;
-  href?: string;
+  href?: string | (() => void);
   icon?: ReactNode;
   lastUpdated?: string;
   period?: string;
@@ -39,8 +39,10 @@ export const TableCard = forwardRef<HTMLDivElement, TableCardProps>(
   ) => {
     const handleClick = () => {
       const noTextSelected = !window.getSelection()?.toString();
-      if (noTextSelected && href) {
+      if (noTextSelected && href && typeof href === 'string') {
         window.location.href = href;
+      } else if (noTextSelected && typeof href === 'function') {
+        href();
       }
     };
 

--- a/packages/pxweb2/src/app/pages/StartPage/StartPage.tsx
+++ b/packages/pxweb2/src/app/pages/StartPage/StartPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useContext, useState, useRef } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import type { TFunction } from 'i18next';
 import { motion, AnimatePresence } from 'framer-motion';
 import cl from 'clsx';
@@ -77,6 +78,8 @@ const StartPage = () => {
   const hasFetchedRef = useRef(false);
   const hasEverHydratedRef = useRef(false);
   const previousLanguage = useRef('');
+
+  const navigate = useNavigate();
 
   const isReadyToRender = tableListIsReadyToRender(
     state,
@@ -312,7 +315,11 @@ const StartPage = () => {
         <TableCard
           key={table.id}
           title={`${table.label}`}
-          href={`${config.baseApplicationPath}${langPrefix}/table/${table.id}`}
+          href={() =>
+            navigate(
+              `${config.baseApplicationPath}${langPrefix}/table/${table.id}`,
+            )
+          }
           updatedLabel={
             table.updated ? t('start_page.table.updated_label') : undefined
           }


### PR DESCRIPTION
Also changes signature of TableCard component to take either a string or a function returning void, in order to accept the navigate function of react-router