### PR TITLE
Fix/linter and testing cleanup

### DIFF
--- a/packages/pxweb2-ui/src/lib/util/setupTests.ts
+++ b/packages/pxweb2-ui/src/lib/util/setupTests.ts
@@ -20,13 +20,11 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      changeLanguage: () => new Promise(() => {}),
+      changeLanguage: () => new Promise(vi.fn()),
     },
   }),
   initReactI18next: {
     type: '3rdParty',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    init: () => {},
+    init: vi.fn(),
   },
 }));

--- a/packages/pxweb2/src/app/components/ContentTop/ContentTop.spec.tsx
+++ b/packages/pxweb2/src/app/components/ContentTop/ContentTop.spec.tsx
@@ -321,8 +321,9 @@ let mockIsXXLargeDesktop = true;
 vi.mock('../../context/useApp', () => ({
   default: () => ({
     isXXLargeDesktop: mockIsXXLargeDesktop,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    setTitle: () => {},
+    setTitle: () => {
+      vi.fn();
+    },
   }),
 }));
 

--- a/packages/pxweb2/src/app/components/StartPageDetails/StartPageDetails.spec.tsx
+++ b/packages/pxweb2/src/app/components/StartPageDetails/StartPageDetails.spec.tsx
@@ -1,15 +1,9 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
-import StartPageDetails from './StartPageDetails';
 
-let mockLanguage = 'no';
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    i18n: { language: mockLanguage },
-    t: (key: string) => key,
-  }),
-}));
+import StartPageDetails from './StartPageDetails';
 
 vi.mock('../../util/hooks/useLocaleContent', () => ({
   useLocaleContent: vi.fn(),
@@ -35,13 +29,15 @@ const detailsSectionNo = {
 
 describe('StartPageDetails (renders from props)', () => {
   it('renders header and body from props', async () => {
+    const user = userEvent.setup();
     render(<StartPageDetails detailsSection={detailsSectionNo} />);
 
     const toggle = await screen.findByRole('button', {
       name: 'Mer om Statistikkbanken',
     });
     expect(toggle).toBeInTheDocument();
-    toggle.click();
+
+    await user.click(toggle);
     await waitFor(() =>
       expect(toggle).toHaveAttribute('aria-expanded', 'true'),
     );

--- a/packages/pxweb2/src/app/context/TableDataProvider.tsx
+++ b/packages/pxweb2/src/app/context/TableDataProvider.tsx
@@ -49,16 +49,21 @@ interface TableDataProviderProps {
 const TableDataContext = createContext<TableDataContextType | undefined>({
   isInitialized: false,
   data: undefined,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  fetchTableData: () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  fetchSavedQuery: () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  pivotToMobile: () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  pivotToDesktop: () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  pivotCW: () => {},
+  fetchTableData: () => {
+    // No-op: useTableData hook prevents this from being called
+  },
+  fetchSavedQuery: () => {
+    // No-op: useTableData hook prevents this from being called
+  },
+  pivotToMobile: () => {
+    // No-op: useTableData hook prevents this from being called
+  },
+  pivotToDesktop: () => {
+    // No-op: useTableData hook prevents this from being called
+  },
+  pivotCW: () => {
+    // No-op: useTableData hook prevents this from being called
+  },
   buildTableTitle: () => {
     return {
       firstTitlePart: '',

--- a/packages/pxweb2/src/app/context/VariablesProvider.tsx
+++ b/packages/pxweb2/src/app/context/VariablesProvider.tsx
@@ -31,16 +31,18 @@ export type VariablesContextType = {
 // Create the context with default values
 export const VariablesContext = createContext<VariablesContextType>({
   isInitialized: false,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  addSelectedValues: () => {},
+  addSelectedValues: () => {
+    // No-op: useVariables hook prevents this from being called
+  },
 
   getSelectedValuesById: () => [],
   getSelectedValuesByIdSorted: () => [],
   getSelectedCodelistById: () => undefined,
 
   getNumberOfSelectedValues: () => 0,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  syncVariablesAndValues: () => {},
+  syncVariablesAndValues: () => {
+    // No-op: useVariables hook prevents this from being called
+  },
   getSelectedMatrixSize: () => 1,
   getUniqueIds: () => [],
   toString: () => '',

--- a/packages/pxweb2/src/app/pages/StartPage/StartPage.spec.tsx
+++ b/packages/pxweb2/src/app/pages/StartPage/StartPage.spec.tsx
@@ -1,14 +1,15 @@
-import { MemoryRouter } from 'react-router';
-import type { Table } from '@pxweb2/pxweb2-api-client';
-import StartPage from './StartPage';
-import { AccessibilityProvider } from '../../context/AccessibilityProvider';
-import { renderWithProviders } from '../../util/testing-utils';
-import { Config } from '../../util/config/configType';
 import { vi, Mock } from 'vitest';
-import '@testing-library/jest-dom/vitest';
+import { MemoryRouter } from 'react-router';
 import { waitFor, within } from '@testing-library/react';
-import { sortTablesByUpdated } from '../../util/startPageFilters';
+import '@testing-library/jest-dom/vitest';
+
+import StartPage from './StartPage';
+import type { Table } from '@pxweb2/pxweb2-api-client';
+import { AccessibilityProvider } from '../../context/AccessibilityProvider';
+import { Config } from '../../util/config/configType';
 import { useLocaleContent } from '../../util/hooks/useLocaleContent';
+import { sortTablesByUpdated } from '../../util/startPageFilters';
+import { renderWithProviders } from '../../util/testing-utils';
 
 // Mock the getAllTables function
 vi.mock('../../util/tableHandler', () => ({
@@ -126,8 +127,12 @@ window.PxWeb2Config = {
     showDefaultLanguageInPath: true,
   },
   apiUrl: 'https://api.scb.se/OV0104/v2beta/api/v2',
+  baseApplicationPath: '/',
   maxDataCells: 100000,
   specialCharacters: ['.', '..', ':', '-', '...', '*'],
+  variableFilterExclusionList: {
+    en: ['ContentsCode', 'Tid'],
+  },
 };
 
 describe('StartPage', () => {
@@ -344,7 +349,10 @@ describe('StartPage locale content: breadcrumbs', () => {
       </AccessibilityProvider>,
     );
 
-    expect(queryByRole('link', { name: 'Forsiden' })).not.toBeInTheDocument();
+    // Wait for component to stabilize after async state updates
+    await waitFor(() => {
+      expect(queryByRole('link', { name: 'Forsiden' })).not.toBeInTheDocument();
+    });
   });
 
   it('does not render breadcrumbs when breadCrumb is missing', async () => {
@@ -360,6 +368,9 @@ describe('StartPage locale content: breadcrumbs', () => {
       </AccessibilityProvider>,
     );
 
-    expect(queryByRole('link', { name: 'Forsiden' })).not.toBeInTheDocument();
+    // Wait for component to stabilize after async state updates
+    await waitFor(() => {
+      expect(queryByRole('link', { name: 'Forsiden' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/pxweb2/src/app/pages/TopicIcons/TopicIcons.spec.tsx
+++ b/packages/pxweb2/src/app/pages/TopicIcons/TopicIcons.spec.tsx
@@ -40,10 +40,19 @@ describe('TopicIcons', () => {
   });
 
   it('shows "No icons found" if fetch fails', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(vi.fn());
+
     (fetch as Mock).mockRejectedValueOnce(new Error('boom'));
     render(<TopicIcons />);
 
     const msg = await screen.findByText(/No icons found/i);
     expect(msg).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Could not load icon list: boom',
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/pxweb2/src/app/pages/TopicIcons/TopicIcons.tsx
+++ b/packages/pxweb2/src/app/pages/TopicIcons/TopicIcons.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+
 import { Heading, Label } from '@pxweb2/pxweb2-ui';
 import styles from './TopicIcons.module.scss';
 
@@ -17,7 +18,7 @@ export const TopicIcons: React.FC = () => {
         );
         setFiles(svgFiles);
       })
-      .catch((e) => console.error(`Kunne ikke laste ikonliste: ${e.message}`));
+      .catch((e) => console.error(`Could not load icon list: ${e.message}`));
   }, []);
 
   if (!files?.length) {

--- a/packages/pxweb2/src/app/util/config/getConfig.ts
+++ b/packages/pxweb2/src/app/util/config/getConfig.ts
@@ -1,4 +1,12 @@
 import { Config } from './configType';
+
+// Extend the global Window interface to include PxWeb2Config
+declare global {
+  interface Window {
+    PxWeb2Config: Config;
+  }
+}
+
 export const getConfig = () => {
-  return (window as any).PxWeb2Config as Config;
+  return window.PxWeb2Config;
 };

--- a/packages/pxweb2/src/app/util/content/localeContent.spec.ts
+++ b/packages/pxweb2/src/app/util/content/localeContent.spec.ts
@@ -18,7 +18,12 @@ beforeEach(async () => {
   const mod = await import('./localeContent');
   fetchLocaleContent = mod.fetchLocaleContent;
 
-  (globalThis as any).fetch = vi.fn() as FetchMock;
+  // Type-safe way to mock global fetch
+  Object.defineProperty(globalThis, 'fetch', {
+    value: vi.fn() as FetchMock,
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
@@ -54,6 +59,7 @@ describe('fetchLocaleContent', () => {
 
     const no2 = await fetchLocaleContent('no');
     const en2 = await fetchLocaleContent('en');
+
     expect(no2).toEqual({ title: 'Startside NO' });
     expect(en2).toEqual({ title: 'Homepage EN' });
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);

--- a/packages/pxweb2/test/setupTests.ts
+++ b/packages/pxweb2/test/setupTests.ts
@@ -1,6 +1,21 @@
 import React from 'react';
 import { vi } from 'vitest';
 
+// Types for motion props to avoid using 'any'
+interface MotionProps extends React.HTMLAttributes<HTMLElement> {
+  whileHover?: unknown;
+  whileTap?: unknown;
+  variants?: unknown;
+  initial?: unknown;
+  animate?: unknown;
+  exit?: unknown;
+  transition?: unknown;
+  layout?: unknown;
+  layoutId?: string;
+  children?: React.ReactNode;
+  className?: string;
+}
+
 // Global mock for getConfig
 vi.mock('../src/app/util/config/getConfig', () => ({
   getConfig: () => ({
@@ -29,8 +44,7 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      changeLanguage: () => new Promise(() => {}),
+      changeLanguage: () => new Promise(vi.fn()),
       language: 'en',
       dir: () => 'ltr',
     },
@@ -40,19 +54,17 @@ vi.mock('react-i18next', () => ({
   useNavigate: vi.fn(() => vi.fn()),
   initReactI18next: {
     type: '3rdParty',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    init: () => {},
+    init: vi.fn(),
   },
 }));
 
 // Mock motion/react components to avoid DOM access issues in tests
-/* eslint-disable @typescript-eslint/no-explicit-any */
 vi.mock('motion/react', () => ({
   LazyMotion: ({ children }: { children: React.ReactNode }) => children,
   MotionConfig: ({ children }: { children: React.ReactNode }) => children,
   LayoutGroup: ({ children }: { children: React.ReactNode }) => children,
   m: {
-    div: ({ children, className, ...props }: any) => {
+    div: ({ children, className, ...props }: MotionProps) => {
       // Filter out motion-specific props to avoid React warnings
       const {
         whileHover,
@@ -77,7 +89,7 @@ vi.mock('motion/react', () => ({
         layoutId;
       return React.createElement('div', { className, ...restProps }, children);
     },
-    button: ({ children, className, ...props }: any) => {
+    button: ({ children, className, ...props }: MotionProps) => {
       // Filter out motion-specific props to avoid React warnings
       const {
         whileHover,
@@ -106,7 +118,7 @@ vi.mock('motion/react', () => ({
         children,
       );
     },
-    span: ({ children, className, ...props }: any) => {
+    span: ({ children, className, ...props }: MotionProps) => {
       // Filter out motion-specific props to avoid React warnings
       const {
         whileHover,
@@ -133,7 +145,7 @@ vi.mock('motion/react', () => ({
     },
   },
   motion: {
-    div: ({ children, className, ...props }: any) => {
+    div: ({ children, className, ...props }: MotionProps) => {
       // Filter out motion-specific props to avoid React warnings
       const {
         whileHover,
@@ -158,7 +170,7 @@ vi.mock('motion/react', () => ({
         layoutId;
       return React.createElement('div', { className, ...restProps }, children);
     },
-    button: ({ children, className, ...props }: any) => {
+    button: ({ children, className, ...props }: MotionProps) => {
       // Filter out motion-specific props to avoid React warnings
       const {
         whileHover,
@@ -187,7 +199,7 @@ vi.mock('motion/react', () => ({
         children,
       );
     },
-    span: ({ children, className, ...props }: any) => {
+    span: ({ children, className, ...props }: MotionProps) => {
       // Filter out motion-specific props to avoid React warnings
       const {
         whileHover,


### PR DESCRIPTION
This fixes a few more linter warnings, and also removes some "eslint-disable" lines and fixes the issues they ignored. Lastly it also fixes the few tests that were spamming the test output again.