### PR TITLE
Fix/lint warnings

### DIFF
--- a/packages/pxweb2/src/app/components/Footer/Footer.spec.tsx
+++ b/packages/pxweb2/src/app/components/Footer/Footer.spec.tsx
@@ -142,9 +142,9 @@ describe('Footer', () => {
 
     it('scrolls window to top when enableWindowScroll is true', () => {
       (useLocaleContent as Mock).mockReturnValue(footerContent);
-      const scrollSpy = vi
-        .spyOn(window, 'scrollTo')
-        .mockImplementation(() => {});
+      const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
+        vi.fn();
+      });
       render(<Footer variant="startpage" enableWindowScroll />);
 
       const btn = screen.getByRole('button', {


### PR DESCRIPTION
This fixes a couple of linter warnings that were introduced in the last few days:

1 - Footer test: Mock a no-op in an empty function
2 - Bigger rework of types in the FilterSidebar, to get rid of 2 any types

Used Sonnet 4.5 on the FilterSidebar