### PR TITLE
Fix href creation for TableCard in StartPage

### DIFF
--- a/packages/pxweb2/src/app/pages/StartPage/StartPage.tsx
+++ b/packages/pxweb2/src/app/pages/StartPage/StartPage.tsx
@@ -308,7 +308,7 @@ const StartPage = () => {
       const showLangInPath =
         config.language.showDefaultLanguageInPath ||
         language !== config.language.defaultLanguage;
-      const langPrefix = showLangInPath ? `${language}` : '';
+      const langPrefix = showLangInPath ? `${language}/` : '';
       const discontinued = table.discontinued;
 
       let cardRef: React.RefObject<HTMLDivElement | null> | undefined;
@@ -322,7 +322,7 @@ const StartPage = () => {
         <TableCard
           key={table.id}
           title={`${table.label}`}
-          href={() => navigate(`/${langPrefix}/table/${table.id}`)}
+          href={() => navigate(`/${langPrefix}table/${table.id}`)}
           updatedLabel={
             table.updated ? t('start_page.table.updated_label') : undefined
           }


### PR DESCRIPTION
The current implementation adds another '/', even when the URL should not have the default language. Which makes those links not work when clicked: '//table...' instead of '/table...'.