### PR TITLE
Add default color to Icon CSS

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Icon/Icon.module.scss
+++ b/packages/pxweb2-ui/src/lib/components/Icon/Icon.module.scss
@@ -2,4 +2,6 @@
   width: 1.5rem;
   height: 1.5rem;
   flex-shrink: 0;
+
+  color: var(--px-color-icon-default);
 }

--- a/packages/pxweb2-ui/src/lib/components/Icon/Icon.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Icon/Icon.spec.tsx
@@ -1,10 +1,112 @@
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 
 import { Icon } from './Icon';
+import styles from './Icon.module.scss';
 
 describe('Icon', () => {
-  it('should render successfully', () => {
-    const { baseElement } = render(<Icon iconName="ChevronDown" />);
-    expect(baseElement).toBeTruthy();
+  it('should render an SVG element', () => {
+    const { container } = render(<Icon iconName="ChevronDown" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('should render the correct icon', () => {
+    const { container } = render(<Icon iconName="Check" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('should apply default className', () => {
+    const { container } = render(<Icon iconName="Heart" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveClass(styles.icon);
+  });
+
+  it('should apply custom className along with default', () => {
+    const { container } = render(
+      <Icon iconName="Bell" className="custom-class" />,
+    );
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveClass(styles.icon);
+    expect(svg).toHaveClass('custom-class');
+  });
+
+  it('should have correct SVG attributes', () => {
+    const { container } = render(<Icon iconName="Table" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg).toHaveAttribute('fill', 'currentColor');
+  });
+
+  it('should apply aria-label when provided', () => {
+    const { container } = render(
+      <Icon iconName="MagnifyingGlass" ariaLabel="Search icon" />,
+    );
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveAttribute('aria-label', 'Search icon');
+  });
+
+  it('should not have aria-label when not provided', () => {
+    const { container } = render(<Icon iconName="XMark" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).not.toHaveAttribute('aria-label');
+  });
+
+  it('should apply aria-hidden when true', () => {
+    const { container } = render(<Icon iconName="Pencil" ariaHidden={true} />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should not have aria-hidden when not provided', () => {
+    const { container } = render(<Icon iconName="Clock" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('should return null for non-existent icon', () => {
+    const { container } = render(
+      // Cast to any to bypass TypeScript checks, for testing purposes
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <Icon iconName={'NonExistentIcon' as any} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should handle empty className correctly', () => {
+    const { container } = render(<Icon iconName="Bookmark" className="" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveClass(styles.icon);
+    expect(svg?.getAttribute('class')).toBe(styles.icon);
+  });
+
+  it('should render filled icon variants', () => {
+    const { container } = render(<Icon iconName="HeartFilled" />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('should render with both aria-label and aria-hidden', () => {
+    const { container } = render(
+      <Icon iconName="Bell" ariaLabel="Notification" ariaHidden={true} />,
+    );
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveAttribute('aria-label', 'Notification');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
   });
 });

--- a/packages/pxweb2-ui/src/lib/components/Icon/Icon.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Icon/Icon.tsx
@@ -10,11 +10,12 @@ export interface IconProps {
 
 const Icon: React.FC<IconProps> = ({
   iconName,
-  className,
+  className = '',
   ariaLabel,
   ariaHidden,
 }) => {
   const icon = Icons[iconName];
+  const cssClasses = className.length > 0 ? ' ' + className : '';
 
   if (!icon) {
     return null;
@@ -24,7 +25,7 @@ const Icon: React.FC<IconProps> = ({
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      className={className + ' ' + styles['icon']}
+      className={styles['icon'] + cssClasses}
       fill="currentColor"
       {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
       {...(ariaHidden ? { 'aria-hidden': ariaHidden } : {})}


### PR DESCRIPTION
This fixes the bug where icons were missing default colors, and therefore showing up as user agent colors in different browsers. Like turning blue in iOS.