### PR TITLE
Omit empty target attribute when not provided

### DIFF
--- a/packages/pxweb2-ui/src/lib/components/Link/Link.spec.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Link/Link.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 
 import Link from './Link';
 
@@ -13,11 +14,11 @@ describe('Link', () => {
     expect(link.getAttribute('href')).toBe('#');
   });
 
-  it('sets empty target attribute when target prop is not provided', () => {
+  it('omits target attribute when target prop is not provided', () => {
     render(<Link href="#">{linkText}</Link>);
     const link = screen.getByRole('link');
-    // target="" is explicitly set in component when no target passed
-    expect(link.getAttribute('target')).toBe('');
+    expect(link).not.toHaveAttribute('target');
+    expect(link.getAttribute('target')).toBeNull();
   });
 
   it('applies target attribute when provided', () => {

--- a/packages/pxweb2-ui/src/lib/components/Link/Link.tsx
+++ b/packages/pxweb2-ui/src/lib/components/Link/Link.tsx
@@ -32,7 +32,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   return (
     <a
       href={href}
-      target={target ? target : ''}
+      target={target}
       className={cl(classes.link, {
         [classes.no_underline]: noUnderline,
         [classes.inline]: inline,


### PR DESCRIPTION
html-validate reported invalid emptry string for target attribute