### PR TITLE
Make Parquet available for download again

### DIFF
--- a/packages/pxweb2/src/app/constants/outputFormats.ts
+++ b/packages/pxweb2/src/app/constants/outputFormats.ts
@@ -33,9 +33,9 @@ export const fileFormats: FileFormat[] = [
     outputFormat: OutputFormatType.HTML,
     iconName: 'FileCode',
   },
-  // {
-  //   value: 'parquet',
-  //   outputFormat: OutputFormatType.PARQUET,
-  //   iconName: 'FileCode',
-  // },
+  {
+    value: 'parquet',
+    outputFormat: OutputFormatType.PARQUET,
+    iconName: 'FileCode',
+  },
 ];


### PR DESCRIPTION
Reintroduced _Parquet_ as a supported file format (closes #1240 )