### PR TITLE
refactor: Change to non-action solution for PR deployment comments

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -81,7 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
       pull-requests: write
 
       # Only deploy for PRs created by non-dependabot users from the main repository (not forks)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build:
@@ -80,8 +79,13 @@ jobs:
     name: Deploy to Cloudflare Pages
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
-    if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' }}
+      # Only deploy for PRs created by non-dependabot users from the main repository (not forks)
+    if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
     outputs:
       deployment-url: ${{ steps.deploy.outputs.deployment-url }}
       alias-url: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
@@ -135,16 +139,36 @@ jobs:
             pages deploy dist --branch=alternative-${{ steps.branch-names.outputs.current_branch }}
 
       - name: Add deployment info to PR description
-        uses: jupier/powerful-pr-comment@v0.0.5
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          sticky: true
-          body: |
-            ## Branch Deployment to Cloudflare Pages
-            :articulated_lorry: Preview URL: ${{ steps.deploy.outputs.deployment-url }}
-            :construction: Branch preview URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
-            :truck: Alternative Preview URL: ${{ steps.alt-deploy.outputs.deployment-url }}
-            :construction_worker: Alternative Branch preview URL: ${{ steps.alt-deploy.outputs.pages-deployment-alias-url }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          DEPLOY_ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+          ALT_DEPLOY_URL: ${{ steps.alt-deploy.outputs.deployment-url }}
+          ALT_DEPLOY_ALIAS_URL: ${{ steps.alt-deploy.outputs.pages-deployment-alias-url }}
+        run: |
+          set -euo pipefail
+
+          for required_var in REPO PR_NUMBER DEPLOY_URL DEPLOY_ALIAS_URL ALT_DEPLOY_URL ALT_DEPLOY_ALIAS_URL; do
+            if [ -z "${!required_var}" ]; then
+              echo "::error::Missing required value: ${required_var}"
+              exit 1
+            fi
+          done
+
+          comment_body="$(printf '%s\n' \
+            '## Branch Deployment to Cloudflare Pages' \
+            ":articulated_lorry: Preview URL: ${DEPLOY_URL}" \
+            ":construction: Branch preview URL: ${DEPLOY_ALIAS_URL}" \
+            ":truck: Alternative Preview URL: ${ALT_DEPLOY_URL}" \
+            ":construction_worker: Alternative Branch preview URL: ${ALT_DEPLOY_ALIAS_URL}")"
+
+          gh pr comment "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --body "$comment_body" \
+            --edit-last \
+            --create-if-none
 
   test:
     name: Run Mabl tests

--- a/packages/pxweb2-ui/README.md
+++ b/packages/pxweb2-ui/README.md
@@ -1,1 +1,1 @@
-# pxweb2-ui 
+# pxweb2-ui


### PR DESCRIPTION
Update the deploy jobs "Add PR comment" job to no longer use an action, since many such actions seem unmaintained. Refactored to manually do this using GitHub CLI.

Fixes number 1 in https://github.com/PxTools/PxWeb2/issues/1229