### PR TITLE
Add packageManager field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "engines": {
     "node": ">=24"
   },
+  "packageManager": "npm@11.13.0",
   "readme": "ERROR: No README data found!",
   "_id": "@pxweb2/source@0.0.0",
   "workspaces": [


### PR DESCRIPTION
This adds a packageManager field with a set npm version to the package.json file, in an attempt to make the dependabot updates use that version.

The reason for this is that we are seeing some unrelated changes in the dependabot updates, that we suspect are because it resolves to an older npm version (11.8.0). Setting the npm version to the  one that comes packaged with the newest node lts version (11.13.0).

Running "npm audit fix" with node v24.16.0 and npm v11.13.0 gives no changes.
Running "npx npm@11.8.0 audit fix" removes alot of libc fields, like we are seeing.