### PR TITLE
fix: ensure parent subject filter is correctly restored during sibling removal

### DIFF
--- a/packages/pxweb2/src/app/components/FilterSidebar/FilterSidebar.spec.tsx
+++ b/packages/pxweb2/src/app/components/FilterSidebar/FilterSidebar.spec.tsx
@@ -50,7 +50,7 @@ vi.mock('@pxweb2/pxweb2-ui', () => ({
     </label>
   ),
   Search: () => <div data-testid="search-stub" />,
-  SearchSelect: (props: { label: string; value: string }) => (
+  SearchSelect: (props: { label: string }) => (
     <div
       data-testid="searchselect-stub"
       aria-label={props?.label ?? 'SearchSelect'}
@@ -74,6 +74,7 @@ const makeBaseState = (
   overrides: Partial<StartPageState> = {},
 ): StartPageState => ({
   availableTables: [],
+  availableTablesWhenQueryApplied: [],
   activeFilters: [],
   availableFilters: {
     subjectTree: [],
@@ -343,6 +344,171 @@ describe('FilterSidebar - TimeUnit filter', () => {
           value: 'Monthly',
           label: 'start_page.filter.frequency.monthly',
           index: 1,
+        },
+      ],
+    });
+  });
+});
+
+describe('FilterSidebar - Subject filter', () => {
+  it('does not restore the parent subject when another sibling subject is still active', async () => {
+    const state = makeBaseState({
+      activeFilters: [
+        {
+          type: 'subject',
+          value: 'al03',
+          label: 'Arbeidsledighet',
+          uniqueId: 'al__al03',
+          index: 0,
+        },
+        {
+          type: 'subject',
+          value: 'al06',
+          label: 'Sysselsetting',
+          uniqueId: 'al__al06',
+          index: 1,
+        },
+      ],
+      availableFilters: {
+        subjectTree: [
+          {
+            id: 'al',
+            label: 'Arbeid og lønn',
+            uniqueId: 'al',
+            count: 2,
+            children: [
+              {
+                id: 'al03',
+                label: 'Arbeidsledighet',
+                uniqueId: 'al__al03',
+                count: 1,
+                children: [],
+              },
+              {
+                id: 'al06',
+                label: 'Sysselsetting',
+                uniqueId: 'al__al06',
+                count: 1,
+                children: [],
+              },
+            ],
+          },
+        ],
+        timeUnits: new Map(),
+        variables: new Map(),
+        status: new Map(),
+        yearRange: { min: 0, max: 0 },
+      },
+    });
+
+    const dispatch = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithFilterContext(state, dispatch);
+
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: 'Arbeidsledighet (1)',
+      }),
+    );
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: ActionType.REMOVE_FILTERS,
+      payload: [
+        {
+          value: 'al03',
+          type: 'subject',
+          uniqueId: 'al__al03',
+        },
+      ],
+    });
+    expect(dispatch).not.toHaveBeenCalledWith({
+      type: ActionType.ADD_FILTER,
+      payload: [
+        {
+          type: 'subject',
+          value: 'al',
+          label: 'Arbeid og lønn',
+          uniqueId: 'al',
+          index: 0,
+        },
+      ],
+    });
+  });
+
+  it('restores the parent subject when all sibling subjects are inactive', async () => {
+    const state = makeBaseState({
+      activeFilters: [
+        {
+          type: 'subject',
+          value: 'al03',
+          label: 'Arbeidsledighet',
+          uniqueId: 'al__al03',
+          index: 0,
+        },
+      ],
+      availableFilters: {
+        subjectTree: [
+          {
+            id: 'al',
+            label: 'Arbeid og lønn',
+            uniqueId: 'al',
+            count: 2,
+            children: [
+              {
+                id: 'al03',
+                label: 'Arbeidsledighet',
+                uniqueId: 'al__al03',
+                count: 1,
+                children: [],
+              },
+              {
+                id: 'al06',
+                label: 'Sysselsetting',
+                uniqueId: 'al__al06',
+                count: 1,
+                children: [],
+              },
+            ],
+          },
+        ],
+        timeUnits: new Map(),
+        variables: new Map(),
+        status: new Map(),
+        yearRange: { min: 0, max: 0 },
+      },
+    });
+
+    const dispatch = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithFilterContext(state, dispatch);
+
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: 'Arbeidsledighet (1)',
+      }),
+    );
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: ActionType.REMOVE_FILTERS,
+      payload: [
+        {
+          value: 'al03',
+          type: 'subject',
+          uniqueId: 'al__al03',
+        },
+      ],
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: ActionType.ADD_FILTER,
+      payload: [
+        {
+          type: 'subject',
+          value: 'al',
+          label: 'Arbeid og lønn',
+          uniqueId: 'al',
+          index: 0,
         },
       ],
     });

--- a/packages/pxweb2/src/app/components/FilterSidebar/FilterSidebar.tsx
+++ b/packages/pxweb2/src/app/components/FilterSidebar/FilterSidebar.tsx
@@ -29,8 +29,10 @@ interface FilterSidebarProps {
 
 // Handles one subject node in the tree.
 // Checked means this node is selected as the representative filter.
-// Unchecked means this node and its descendants are removed, then the nearest
-// ancestor is restored to keep parent-level selection stable.
+// Unchecked means this node and its descendants are removed. The nearest
+// ancestor is only restored when no other active descendant remains under that
+// same ancestor, so sibling selections stay explicit instead of collapsing back
+// to the parent subject.
 const Collapsible: React.FC<CollapsibleProps> = ({
   subject,
   index,
@@ -43,6 +45,9 @@ const Collapsible: React.FC<CollapsibleProps> = ({
   const subjectId = subject.id;
   const subjectLabel = subject.label;
   const subjectTree = state.availableFilters.subjectTree;
+  const activeSubjectFilters = state.activeFilters.filter(
+    (filter) => filter.type === 'subject',
+  );
 
   return (
     <div className={styles.filterLabel}>
@@ -95,6 +100,14 @@ const Collapsible: React.FC<CollapsibleProps> = ({
             // Deselecting a node clears that node and every descendant.
             const descendants = [subject, ...children];
 
+            // We need to check if any of the removed filters are still active as siblings under the same parent,
+            // so we keep track of their uniqueIds in a set for O(1) lookups.
+            const removedUniqueIds = new Set(
+              descendants
+                .map((descendant) => descendant.uniqueId)
+                .filter((uniqueId): uniqueId is string => !!uniqueId),
+            );
+
             dispatch({
               type: ActionType.REMOVE_FILTERS,
               payload: descendants.map((d) => ({
@@ -104,15 +117,29 @@ const Collapsible: React.FC<CollapsibleProps> = ({
               })),
             });
 
-            // Restore nearest ancestor if needed so parent-level selection
-            // remains explicit in the active filter list.
-            const parent: PathItem | undefined = ancestors.length
-              ? ancestors[ancestors.length - 1]
-              : undefined;
+            // Subject uniqueIds encode the full tree path, so a shared prefix
+            // lets us detect whether another branch under the same parent is
+            // still active without re-walking the subtree. If another child is
+            // still selected, we must not promote the parent back into the
+            // active filter list.
+            const parent = ancestors.at(-1);
+            const hasRemainingActiveDescendantUnderParent =
+              !!parent?.uniqueId &&
+              activeSubjectFilters.some(
+                (filter) =>
+                  // Must share the same parent uniqueId prefix to be a sibling, but must not be one we just removed.
+                  !!filter.uniqueId &&
+                  filter.uniqueId.startsWith(`${parent.uniqueId}__`) &&
+                  !removedUniqueIds.has(filter.uniqueId),
+              );
             const isParentInFilter = state.activeFilters.some(
               (f) => f.type === 'subject' && f.value === parent?.id,
             );
-            if (parent && !isParentInFilter) {
+            if (
+              parent &&
+              !isParentInFilter &&
+              !hasRemainingActiveDescendantUnderParent
+            ) {
               dispatch({
                 type: ActionType.ADD_FILTER,
                 payload: [


### PR DESCRIPTION
This fixes a bug in the "subjects" filter, where the parent is added when a child is removed, even if there still are other siblings still active

Fixes https://github.com/PxTools/PxWeb2/issues/1289