### PR TITLE
fix: Make the variable filter's height dynamic

### DIFF
--- a/packages/pxweb2/src/app/components/FilterSidebar/FilterSidebar.module.scss
+++ b/packages/pxweb2/src/app/components/FilterSidebar/FilterSidebar.module.scss
@@ -72,7 +72,7 @@
   word-break: break-word;
 
   // Set container height to show 11.5 items. They are 44px tall.
-  height: calc((44px * 11.5));
+  max-height: calc((44px * 11.5));
 }
 
 .variablesSearchBox {


### PR DESCRIPTION
This makes the height of the Variablefilter on the startpage dynamic to the content.