### PR TITLE
build(deps): update Node.js version from 24.14.1-slim to 24.16.0-slim…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.14.1-slim AS build
+FROM node:24.16.0-slim AS build
 WORKDIR /app
 COPY . ./
 RUN npm ci && npm run build-artifact


### PR DESCRIPTION
… in Dockerfile

I think we have gotten dependabot PRs for the new 26.x versions, but they don't enter LTS until the end of the year, so this one was missed.