### PR TITLE
fix(coverage): include additional packages in coverage exclusion list

### DIFF
--- a/packages/pxweb2/vitest.config.ts
+++ b/packages/pxweb2/vitest.config.ts
@@ -24,6 +24,8 @@ export default mergeConfig(
         reporter: ['lcov', 'text'],
         include: ['src/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
         exclude: [
+          '**/pxweb2-api-client/**',
+          '**/pxweb2-ui/**',
           '**/*.stories.{js,ts,tsx}',
           ...coverageConfigDefaults.exclude,
         ],


### PR DESCRIPTION
This removes the duplicate entries in the output when running the coverage command from the root. 

The web app's coverage command now only contains its own coverage output.