### PR TITLE
chore: Update workflow to include Node.js version 26.x for builds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [24.x, 26.x]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
 
       - run: npm ci && npm run build-artifact


### PR DESCRIPTION
This is so we can start seeing any warnings etc. with the newer node and npm versions. They have announced some changes that might affect us.

Also found an old node 22 version that seems to have fallen through the cracks.