### PR TITLE
patch: Update plugin name to match schema validator functionality

### DIFF
--- a/packages/pxweb2/vite-plugin-virtual-module.ts
+++ b/packages/pxweb2/vite-plugin-virtual-module.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from 'vite';
 import Ajv from 'ajv';
 import standaloneCode from 'ajv/dist/standalone';
+
 import * as configSchema from './src/app/util/config/config.schema.json';
 
 export function virtualModulePlugin(): Plugin {
@@ -9,7 +10,7 @@ export function virtualModulePlugin(): Plugin {
   const resolvedModuleId = '\0' + virtualModuleId;
 
   return {
-    name: 'my-virtual-module-plugin',
+    name: 'pxweb2-config-schema-validator',
 
     resolveId(id) {
       if (id === virtualModuleId) {


### PR DESCRIPTION
The vite-config-validator-plugin still has an example name, which does not tell us much when it shows up in the build output. This changes the name to something more descriptive.