### PR TITLE
chore: update html-validate to version 11.5.3 and adjust configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1415,13 +1415,13 @@
       }
     },
     "node_modules/@html-validate/stylish": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-5.2.0.tgz",
-      "integrity": "sha512-7lF57/RTs2tZi0FtgY7Y5CP73Y2GEPPMaJ9PeZKRRUOs7Bt7/Qlqt8kdsAbVMO7GrpuWtUfGvR11riSOryioow==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-6.0.0.tgz",
+      "integrity": "sha512-d1/lI3qIXhGVJF3+MmKEBn1dRX6U4Z+BDaOdDI3E6SXcO+OQ7hC/3mSo6BIjwQlcuV6NdDOKm6QCrzIQL1EezQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.18 || ^22.16 || >= 24.0"
+        "node": "^22.16.0 || >= 24.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -8053,9 +8053,9 @@
       }
     },
     "node_modules/html-validate": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-10.17.0.tgz",
-      "integrity": "sha512-1WO3hgxqSE0YfV12u5V4ZNUO4mulMrfuxEOlmwM9bEeMlqs9g1OE+EXzxQ4KwNojsYFDmaEYcRPf+zUpAzO/WA==",
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-11.5.3.tgz",
+      "integrity": "sha512-YJAqUomHuND2ppz4QoRoWMm4tLHFxGTkqoBDiMjBm9pzictNkEB78q0yT3U9s6oiy9XoEmVC2QEQcube+fMw5g==",
       "dev": true,
       "funding": [
         {
@@ -8065,12 +8065,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@html-validate/stylish": "^5.2.0",
-        "@sidvind/better-ajv-errors": "5.0.0",
+        "@html-validate/stylish": "^6.0.0",
+        "@sidvind/better-ajv-errors": "7.0.0",
         "ajv": "^8.0.0",
-        "glob": "^13.0.0",
         "kleur": "^4.1.0",
-        "minimist": "^1.2.0",
         "prompts": "^2.0.0",
         "semver": "^7.0.0"
       },
@@ -8078,23 +8076,23 @@
         "html-validate": "bin/html-validate.mjs"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.16.0 || >= 24.0.0"
+        "node": "^22.22.0 || >= 24.8.0"
       },
       "peerDependencies": {
-        "@jest/globals": "^28.1.3 || ^29.0.3 || ^30.0.0",
-        "jest": "^28.1.3 || ^29.0.3 || ^30.0.0",
-        "jest-diff": "^28.1.3 || ^29.0.3 || ^30.0.0",
-        "jest-snapshot": "^28.1.3 || ^29.0.3 || ^30.0.0",
-        "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.1"
+        "@jest/globals": "^29.0.3 || ^30.0.0",
+        "@vitest/expect": "^3.0.0 || ^4.0.1",
+        "jest": "^29.0.3 || ^30.0.0",
+        "jest-snapshot": "^29.0.3 || ^30.0.0",
+        "vitest": "^3.0.0 || ^4.0.1"
       },
       "peerDependenciesMeta": {
         "@jest/globals": {
           "optional": true
         },
-        "jest": {
+        "@vitest/expect": {
           "optional": true
         },
-        "jest-diff": {
+        "jest": {
           "optional": true
         },
         "jest-snapshot": {
@@ -8106,19 +8104,16 @@
       }
     },
     "node_modules/html-validate/node_modules/@sidvind/better-ajv-errors": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-5.0.0.tgz",
-      "integrity": "sha512-FeI/V2KGtOaDX+r0akidCGYy79lVR4YnAqk1GFgZFuHADErCAEmtZL4+IdCAcDXHqfZsII3fs9DrfC1pIR+19w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-7.0.0.tgz",
+      "integrity": "sha512-imVsp5D3KxJ8+uUmu2dsLKnFg3qdX952v/L1gZoCa0NO2ivhQWHMpYM2KmpFrRXHWFjlqkNZ/935nxiTqXEi1A==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "kleur": "^4.1.0"
-      },
       "engines": {
-        "node": "^20.19 || ^22.12 || >= 24.0"
+        "node": "^22.12 || >= 24.0"
       },
       "peerDependencies": {
-        "ajv": "^7.0.0 || ^8.0.0"
+        "ajv": "^8.0.0"
       }
     },
     "node_modules/html-validate/node_modules/ajv": {
@@ -14698,7 +14693,7 @@
         "@testing-library/react": "^16.3.2",
         "ajv": "^8.18.0",
         "concurrently": "^10.0.3",
-        "html-validate": "^10.17.0",
+        "html-validate": "^11.5.3",
         "husky": "^9.1.7",
         "playwright": "^1.60.0",
         "vite-plugin-babel": "^1.7.3",

--- a/packages/pxweb2/.htmlvalidate.json
+++ b/packages/pxweb2/.htmlvalidate.json
@@ -1,10 +1,7 @@
 {
-    "extends": [
-      "html-validate:recommended"
-    ],
-  
-    "rules": {
-      "close-order": "error",
-      "void": ["warn", {"style": "omit"}]
-    }
+  "extends": ["html-validate:recommended", "html-validate:prettier"],
+  "rules": {
+    "close-order": "error",
+    "void-style": ["warn", { "style": "omit" }]
   }
+}

--- a/packages/pxweb2/.htmlvalidate.json
+++ b/packages/pxweb2/.htmlvalidate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["html-validate:recommended", "html-validate:prettier"],
+  "extends": ["html-validate:recommended"],
   "rules": {
     "close-order": "error",
     "void-style": ["warn", { "style": "omit" }]

--- a/packages/pxweb2/package.json
+++ b/packages/pxweb2/package.json
@@ -27,7 +27,7 @@
     "@testing-library/react": "^16.3.2",
     "ajv": "^8.18.0",
     "concurrently": "^10.0.3",
-    "html-validate": "^10.17.0",
+    "html-validate": "^11.5.3",
     "husky": "^9.1.7",
     "playwright": "^1.60.0",
     "vite-plugin-babel": "^1.7.3",


### PR DESCRIPTION
The "void" rule was removed quite some time ago, but it seems we had not updated it. Asked AI and the "void-style" fits the old rule.

Tested before and after, and seems to give the same output.