### PR TITLE
build: Enforce npm and node minimum versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 min-release-age=9 # Enforce a dependency release cooldown of x days.
 ignore-scripts=true # Disable lifecycle scripts to prevent potential security risks and unintended side effects during installation.
+engine-strict=true # Enforce strict engine compatibility to ensure that the package is only installed in compatible environments.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "wrangler": "^4.114.0"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=24",
+    "npm": ">=11.13.0"
   },
   "packageManager": "npm@11.13.0",
   "readme": "ERROR: No README data found!",


### PR DESCRIPTION
This enforces the minimum versions require for Node and NPM. 

We have had some issues with older versions being used, resulting in the cooldown not being respected by the npm commands. Or the package-lock file having lines added/removed due to older ways of handling installs and such.