### PR TITLE
build: Update wrangler config to keep vars from dashboard

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "pxweb2",
-  "compatibility_date": "2025-11-27",
-  "pages_build_output_dir": "./packages/pxweb2/dist"
+  "compatibility_date": "2026-08-12",
+  "pages_build_output_dir": "./packages/pxweb2/dist",
+  "keep_vars": true
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "pxweb2",
   "compatibility_date": "2026-08-12",
-  "pages_build_output_dir": "./packages/pxweb2/dist",
-  "keep_vars": true
+  "compatibility_flags": ["nodejs_compat"],
+  "pages_build_output_dir": "./packages/pxweb2/dist"
 }


### PR DESCRIPTION
We see that the cloudflare deploy on main fails with the wrong Node version, even though the dashboard has the NODE_VERSION environment variable set to 24. This adds the "keep_vars" to the wrangler.jsonc file, so they should no longer be discarded when a deploy reads the config file.