### PR TITLE
build: Add vars NODE_VERSION to wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,6 @@
   "compatibility_flags": ["nodejs_compat"],
   "pages_build_output_dir": "./packages/pxweb2/dist",
   "vars": {
-    "NODE_VERSION": "24.13.0"
+    "NODE_VERSION": "24.17.0"
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,5 +3,8 @@
   "name": "pxweb2",
   "compatibility_date": "2026-08-12",
   "compatibility_flags": ["nodejs_compat"],
-  "pages_build_output_dir": "./packages/pxweb2/dist"
+  "pages_build_output_dir": "./packages/pxweb2/dist",
+  "vars": {
+    "NODE_VERSION": "24.13.0"
+  }
 }


### PR DESCRIPTION
The configurations set in the Cloudflare project does not seem to be read, and logs show the deploy on main find no environment variables.

This adds a vars object in the wrangler.jsonc file, with a NODE_VERSION set. Which will hopefully set this version in the cloudflare runs.

If this does not work, we might have to look into doing the Cloudflare Pages deploy of main like the ones in PRs.