### PR TITLE
chore: Add missing engine.npm version to pkg-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "wrangler": "^4.118.0"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=24",
+        "npm": ">=11.13.0"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
When we added the enforcement of the Node and NPM versions, we forgot to run 'npm install' to also update those parts of the package-lock file.

This commit adds that missing part. I ran 'npm install' only.