### PR TITLE
fix: definitionstab show only statistics homepage if wanted

### DIFF
--- a/packages/pxweb2/src/app/components/TableInformation/Definitions/AboutLinks/AboutLinks.tsx
+++ b/packages/pxweb2/src/app/components/TableInformation/Definitions/AboutLinks/AboutLinks.tsx
@@ -21,7 +21,7 @@ function AboutTexts({ title, description }: AboutTextsProps) {
 }
 
 interface AboutLinksProps {
-  readonly definitionsLink: {
+  readonly definitionsLink?: {
     href: string;
     label: string;
   };
@@ -34,7 +34,7 @@ interface AboutLinksProps {
 export function AboutLinks({ definitionsLink, homepageLink }: AboutLinksProps) {
   const { t } = useTranslation();
 
-  if (!definitionsLink) {
+  if (!definitionsLink && !homepageLink) {
     return null;
   }
 
@@ -79,13 +79,14 @@ export function AboutLinks({ definitionsLink, homepageLink }: AboutLinksProps) {
             size="small"
           ></LinkCard>
         )}
-
-        <LinkCard
-          href={definitionsLink.href}
-          icon="Files"
-          headingText={definitionsLinkText}
-          size="small"
-        ></LinkCard>
+        {definitionsLink && definitionsLinkText && (
+          <LinkCard
+            href={definitionsLink.href}
+            icon="Files"
+            headingText={definitionsLinkText}
+            size="small"
+          ></LinkCard>
+        )}
       </div>
     </div>
   );

--- a/packages/pxweb2/src/app/components/TableInformation/Definitions/DefinitionsTab.tsx
+++ b/packages/pxweb2/src/app/components/TableInformation/Definitions/DefinitionsTab.tsx
@@ -10,7 +10,7 @@ interface DefinitionsTabProps {
 }
 
 export function DefinitionsTab({ definitions }: DefinitionsTabProps) {
-  if (!definitions.statisticsDefinitions) {
+  if (!definitions.statisticsDefinitions  && !definitions.statisticsHomepage)  {
     return null;
   }
 

--- a/packages/pxweb2/src/app/components/TableInformation/Definitions/DefinitionsTab.tsx
+++ b/packages/pxweb2/src/app/components/TableInformation/Definitions/DefinitionsTab.tsx
@@ -10,7 +10,7 @@ interface DefinitionsTabProps {
 }
 
 export function DefinitionsTab({ definitions }: DefinitionsTabProps) {
-  if (!definitions.statisticsDefinitions  && !definitions.statisticsHomepage)  {
+  if (!definitions.statisticsDefinitions && !definitions.statisticsHomepage) {
     return null;
   }
 

--- a/packages/pxweb2/src/app/components/TableInformation/TableInformation.tsx
+++ b/packages/pxweb2/src/app/components/TableInformation/TableInformation.tsx
@@ -51,7 +51,7 @@ export function TableInformation({
   const tabsVariant = isMobile ? 'scrollable' : 'fixed';
 
   const definitionsMandatoryLinkExists =
-    definitionsOrUndefined?.statisticsDefinitions !== undefined;
+    definitionsOrUndefined?.statisticsDefinitions || definitionsOrUndefined?.statisticsHomepage !== undefined;
 
   return (
     <SheetComponent

--- a/packages/pxweb2/src/app/components/TableInformation/TableInformation.tsx
+++ b/packages/pxweb2/src/app/components/TableInformation/TableInformation.tsx
@@ -52,7 +52,7 @@ export function TableInformation({
 
   const definitionsMandatoryLinkExists =
     definitionsOrUndefined?.statisticsDefinitions ||
-    definitionsOrUndefined?.statisticsHomepage !== undefined;
+    definitionsOrUndefined?.statisticsHomepage;
 
   return (
     <SheetComponent

--- a/packages/pxweb2/src/app/components/TableInformation/TableInformation.tsx
+++ b/packages/pxweb2/src/app/components/TableInformation/TableInformation.tsx
@@ -51,7 +51,8 @@ export function TableInformation({
   const tabsVariant = isMobile ? 'scrollable' : 'fixed';
 
   const definitionsMandatoryLinkExists =
-    definitionsOrUndefined?.statisticsDefinitions || definitionsOrUndefined?.statisticsHomepage !== undefined;
+    definitionsOrUndefined?.statisticsDefinitions ||
+    definitionsOrUndefined?.statisticsHomepage !== undefined;
 
   return (
     <SheetComponent


### PR DESCRIPTION
This fix ensures that the definitions tab is rendered correctly when data is fetched from the API metadata endpoint.

In the current version of PxWeb2, the Definitions tab is only rendered if data for "about-statistics" is present. This causes a problem when only "statistics-homepage" information is available from the api, as is the case for Sweden.

With this fix, the definition tab will be rendered if eihter "about-statistics" or/and "statistics-homepage" data is present for a table. Relevant LinkCard components will be shown. 