### PR TITLE
fix: Resolve two type errors in Presentation component

### DIFF
--- a/packages/pxweb2/src/app/components/Presentation/Presentation.tsx
+++ b/packages/pxweb2/src/app/components/Presentation/Presentation.tsx
@@ -287,7 +287,7 @@ export function Presentation({
                       selectedCells: t(
                         'number.simple_number_with_zero_decimal',
                         {
-                          value: variables.getSelectedMatrixSize(),
+                          value: String(variables.getSelectedMatrixSize()),
                         },
                       ),
                     },
@@ -301,7 +301,7 @@ export function Presentation({
                     'presentation_page.main_content.table.warnings.to_many_values_selected.maxCells',
                     {
                       maxCells: t('number.simple_number_with_zero_decimal', {
-                        value: config.maxDataCells,
+                        value: String(config.maxDataCells),
                       }),
                     },
                   )}


### PR DESCRIPTION
The t-function expects strings for the values, while they are stored as numbers in the config file. This wraps the functions for getting the values in `String()`.