### PR TITLE
chore: Update node image in dockerfile to latest 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18.1-slim AS build
+FROM node:24.20.0-slim AS build
 WORKDIR /app
 COPY . ./
 RUN npm ci && npm run build-artifact


### PR DESCRIPTION
This updates the node image in the Dockerfile to 24.20.0-slim, the latest 24 version at this time.